### PR TITLE
Retry button for failed stages

### DIFF
--- a/app/Http/Controllers/IssueViewController.php
+++ b/app/Http/Controllers/IssueViewController.php
@@ -46,6 +46,21 @@ class IssueViewController extends Controller
             ->with('success', ucfirst($stage->name->value) . ' stage rejected.');
     }
 
+    public function retry(Stage $stage): RedirectResponse
+    {
+        $stage->load('run.issue');
+
+        if ($stage->status !== StageStatus::Failed) {
+            return redirect()->route('issues.show', $stage->run->issue)
+                ->with('error', 'This stage has not failed.');
+        }
+
+        $this->orchestrator->retryStage($stage);
+
+        return redirect()->route('issues.show', $stage->run->issue)
+            ->with('success', ucfirst($stage->name->value) . ' stage retrying.');
+    }
+
     public function guidance(Run $run, Request $request): RedirectResponse
     {
         $run->load('issue');

--- a/app/Services/OrchestratorService.php
+++ b/app/Services/OrchestratorService.php
@@ -221,6 +221,23 @@ class OrchestratorService
         $this->transitionStage($newStage, ['guidance' => $guidance]);
     }
 
+    public function retryStage(Stage $stage): void
+    {
+        $run = $stage->run;
+
+        $run->update([
+            'status' => RunStatus::Running,
+            'completed_at' => null,
+        ]);
+
+        $run->issue->update(['status' => IssueStatus::InProgress]);
+
+        $newStage = $this->createStage($run, $stage->name, $stage->iteration);
+        $this->recordEvent($newStage, 'retried', 'user');
+
+        $this->transitionStage($newStage);
+    }
+
     public function restart(Run $run): void
     {
         $run->update([

--- a/resources/views/pages/⚡issue.blade.php
+++ b/resources/views/pages/⚡issue.blade.php
@@ -437,11 +437,21 @@ class extends Component {
                             </div>
 
                         @elseif ($latestRun && $latestRun->status === \App\Enums\RunStatus::Failed)
-                            <div class="text-center py-6">
-                                <span class="inline-flex items-center rounded-full bg-error-container/30 text-error px-3 py-1 text-sm font-medium">
-                                    Failed
+                            @php $failedStage = $latestRun->stages()->where('status', \App\Enums\StageStatus::Failed)->latest('id')->first(); @endphp
+                            <div class="mb-4">
+                                <span class="inline-flex items-center rounded-full bg-error-container/30 text-error px-2.5 py-0.5 font-label text-[10px] uppercase tracking-widest">
+                                    Failed{{ $failedStage ? ' — ' . ucfirst($failedStage->name->value) : '' }}
                                 </span>
                             </div>
+                            @if ($failedStage)
+                                <form method="POST" action="{{ route('issues.retry-stage', $failedStage) }}">
+                                    @csrf
+                                    <button type="submit" data-retry-btn
+                                            class="w-full rounded-md bg-error px-4 py-2 text-sm font-medium text-on-error hover:bg-error/90 transition-colors">
+                                        Retry
+                                    </button>
+                                </form>
+                            @endif
 
                         @else
                             <div class="text-center py-6 text-sm text-on-surface-variant">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::post('/sources/{source}/sync', [SourceController::class, 'syncNow'])->nam
 
 Route::post('/issues/stages/{stage}/approve', [IssueViewController::class, 'approve'])->name('issues.approve');
 Route::post('/issues/stages/{stage}/reject', [IssueViewController::class, 'reject'])->name('issues.reject-stage');
+Route::post('/issues/stages/{stage}/retry', [IssueViewController::class, 'retry'])->name('issues.retry-stage');
 Route::post('/issues/runs/{run}/guidance', [IssueViewController::class, 'guidance'])->name('issues.guidance');
 
 Route::livewire('/issues/{issue}', 'pages::issue')->name('issues.show');


### PR DESCRIPTION
## Summary

- Adds `OrchestratorService::retryStage()` — resets run/issue to running, creates a new stage at the same name/iteration, records a `retried` event, and dispatches via `transitionStage` (autonomy rules apply)
- Adds `IssueViewController::retry()` with a guard that the stage is failed
- Adds route `POST /issues/stages/{stage}/retry`
- Updates the failed state in the Actions panel to show the failed stage name and a **Retry** button

Closes #6

## Test plan

- [ ] Trigger a failed stage and confirm the Retry button appears in the Actions panel
- [ ] Click Retry and confirm the stage re-runs
- [ ] Confirm autonomy rules are respected (supervised stages go to AwaitingApproval on retry)
- [ ] Confirm retrying a non-failed stage via direct POST returns an error redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)