### PR TITLE
fix: render preflight doc as HTML

### DIFF
--- a/resources/views/components/markdown.blade.php
+++ b/resources/views/components/markdown.blade.php
@@ -1,0 +1,10 @@
+@props(['content' => '', 'class' => 'prose dark:prose-invert max-w-none'])
+
+{{-- Render markdown with raw HTML escaped. Preflight doc content can come
+     from an LLM; treat as untrusted and disable unsafe links. --}}
+<div {{ $attributes->class($class) }}>
+    {!! \Illuminate\Support\Str::markdown((string) $content, [
+        'html_input' => 'escape',
+        'allow_unsafe_links' => false,
+    ]) !!}
+</div>

--- a/resources/views/pages/⚡issue.blade.php
+++ b/resources/views/pages/⚡issue.blade.php
@@ -3,12 +3,12 @@
 use App\Enums\IssueStatus;
 use App\Models\Issue;
 use Livewire\Attributes\Layout;
-use Livewire\Attributes\Title;
 use Livewire\Component;
 
 new
 #[Layout('layouts::app', ['containerClass' => 'max-w-7xl'])]
-class extends Component {
+class extends Component
+{
     public Issue $issue;
 
     public function title(): string
@@ -165,7 +165,7 @@ class extends Component {
                             @if ($latestRun->preflight_doc)
                                 <details open>
                                     <summary class="cursor-pointer text-sm font-semibold text-on-surface-variant">Preflight Doc</summary>
-                                    <div class="mt-2 prose prose-sm dark:prose-invert max-w-none bg-surface-container rounded-xl p-3 text-xs whitespace-pre-wrap">{{ $latestRun->preflight_doc }}</div>
+                                    <x-markdown :content="$latestRun->preflight_doc" class="mt-2 prose prose-sm dark:prose-invert max-w-none bg-surface-container rounded-xl p-3 text-xs" />
                                 </details>
                             @endif
 

--- a/resources/views/pages/⚡preflight-doc.blade.php
+++ b/resources/views/pages/⚡preflight-doc.blade.php
@@ -8,7 +8,8 @@ use Livewire\Component;
 new
 #[Title('Preflight Doc')]
 #[Layout('layouts::app')]
-class extends Component {
+class extends Component
+{
     public Run $run;
 
     public function mount(): void
@@ -49,9 +50,7 @@ class extends Component {
     </a>
 </div>
 
-<div class="prose dark:prose-invert max-w-none rounded-xl bg-surface-container-low p-6">
-    {!! nl2br(e($doc)) !!}
-</div>
+<x-markdown :content="$doc" class="prose dark:prose-invert max-w-none rounded-xl bg-surface-container-low p-6" />
 
 @if (! empty($history))
     <div class="mt-8">
@@ -65,7 +64,7 @@ class extends Component {
                             (iteration {{ $version['iteration'] }})
                         @endif
                     </summary>
-                    <div class="px-4 pb-4 text-sm text-on-surface-variant whitespace-pre-wrap">{{ $version['doc'] }}</div>
+                    <x-markdown :content="$version['doc']" class="px-4 pb-4 prose prose-sm dark:prose-invert max-w-none text-on-surface-variant" />
                 </details>
             @endforeach
         </div>


### PR DESCRIPTION
## Summary
- Preflight doc was rendered as raw markdown (literal `#`, `##`, `-`, `**` visible) in the issue page live progress panel and on the preflight doc page.
- Added a reusable `<x-markdown>` Blade component that pipes content through `Str::markdown()` (from the already-installed `league/commonmark`) with `html_input => 'escape'` and `allow_unsafe_links => false`, so LLM-authored markdown renders as formatted HTML while raw `<script>`/HTML is neutralized.
- Applied the component at every preflight render site: `issue.blade.php` live progress panel (covers Implement / Verify / Release stages — they all render through this one view), current doc and history entries on `preflight-doc.blade.php`. The edit screen still shows raw markdown in its textarea.

## Test plan
- [x] `php artisan test` — 544 passed (PreflightDocTest and IssueViewTest assertions continue to pass since they check plain-text substrings)
- [x] `vendor/bin/pint` clean on changed files
- [x] Verified XSS escape: `Str::markdown('<script>alert(1)</script>', ['html_input' => 'escape', ...])` returns escaped entities, not a live tag
- [ ] Manual: visit issue page mid-run and `/preflight/doc/{run}` — confirm headings/lists render

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)