### PR TITLE
feat: per-repo intake pause/resume for GitHub sources

### DIFF
--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -6,6 +6,7 @@ use App\Enums\IssueStatus;
 use App\Enums\SourceType;
 use App\Models\Component;
 use App\Models\Issue;
+use App\Models\Repository;
 use App\Models\Source;
 use App\Services\FilterRuleService;
 use App\Services\GitHubClient;
@@ -37,6 +38,7 @@ class SyncSourceIssuesJob implements ShouldQueue
 
         if (! $token) {
             $this->recordError('No OAuth token found for this source.');
+
             return;
         }
 
@@ -74,8 +76,12 @@ class SyncSourceIssuesJob implements ShouldQueue
         $mapped = [];
 
         foreach ($repos as $repoFullName) {
+            if ($this->source->isRepositoryPaused($repoFullName)) {
+                continue;
+            }
+
             [$owner, $repo] = explode('/', $repoFullName, 2);
-            $repository = \App\Models\Repository::firstOrCreate(
+            $repository = Repository::firstOrCreate(
                 ['name' => $repoFullName],
             );
 
@@ -86,7 +92,7 @@ class SyncSourceIssuesJob implements ShouldQueue
                     continue;
                 }
                 $attrs = GitHubClient::mapToIssueAttributes($ghIssue);
-                $attrs['external_id'] = $repoFullName . '#' . $attrs['external_id'];
+                $attrs['external_id'] = $repoFullName.'#'.$attrs['external_id'];
                 $attrs['repository_id'] = $repository->id;
                 $mapped[] = $attrs;
             }
@@ -174,6 +180,7 @@ class SyncSourceIssuesJob implements ShouldQueue
 
         if ($existing) {
             $this->updateExistingIssue($existing, $issueData);
+
             return;
         }
 

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -19,6 +19,7 @@ class Source extends Model
         'last_synced_at',
         'is_active',
         'is_intake_paused',
+        'paused_repositories',
         'backlog_threshold',
         'config',
         'sync_error',
@@ -33,11 +34,17 @@ class Source extends Model
             'last_synced_at' => 'datetime',
             'is_active' => 'boolean',
             'is_intake_paused' => 'boolean',
+            'paused_repositories' => 'array',
             'backlog_threshold' => 'integer',
             'config' => 'array',
             'next_retry_at' => 'datetime',
             'sync_interval' => 'integer',
         ];
+    }
+
+    public function isRepositoryPaused(string $repoFullName): bool
+    {
+        return in_array($repoFullName, $this->paused_repositories ?? [], true);
     }
 
     public function issues(): HasMany

--- a/database/migrations/2026_04_17_000001_add_paused_repositories_to_sources_table.php
+++ b/database/migrations/2026_04_17_000001_add_paused_repositories_to_sources_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sources', function (Blueprint $table) {
+            $table->json('paused_repositories')->nullable()->after('is_intake_paused');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sources', function (Blueprint $table) {
+            $table->dropColumn('paused_repositories');
+        });
+    }
+};

--- a/resources/views/pages/⚡github-select-repos.blade.php
+++ b/resources/views/pages/⚡github-select-repos.blade.php
@@ -37,10 +37,18 @@ class extends Component {
 
     public function save()
     {
+        $selected = array_values($this->selected);
+
+        $paused = array_values(array_intersect(
+            $this->source->paused_repositories ?? [],
+            $selected,
+        ));
+
         $this->source->update([
             'config' => array_merge($this->source->config ?? [], [
-                'repositories' => array_values($this->selected),
+                'repositories' => $selected,
             ]),
+            'paused_repositories' => $paused,
         ]);
 
         session()->flash('success', count($this->selected).' repositories selected for '.$this->source->external_account.'.');

--- a/resources/views/pages/⚡intake.blade.php
+++ b/resources/views/pages/⚡intake.blade.php
@@ -29,6 +29,30 @@ class extends Component {
         $source->update(['is_intake_paused' => ! $source->is_intake_paused]);
     }
 
+    public function togglePauseRepo(int $sourceId, string $repoFullName): void
+    {
+        $source = Source::findOrFail($sourceId);
+
+        if ($source->type->value !== 'github') {
+            return;
+        }
+
+        $repos = $source->config['repositories'] ?? [];
+        if (! in_array($repoFullName, $repos, true)) {
+            return;
+        }
+
+        $paused = $source->paused_repositories ?? [];
+
+        if (in_array($repoFullName, $paused, true)) {
+            $paused = array_values(array_diff($paused, [$repoFullName]));
+        } else {
+            $paused[] = $repoFullName;
+        }
+
+        $source->update(['paused_repositories' => $paused]);
+    }
+
     public function syncNow(int $sourceId): void
     {
         $source = Source::findOrFail($sourceId);
@@ -245,7 +269,10 @@ class extends Component {
 
                     {{-- Repositories (GitHub only) --}}
                     @if ($source->type->value === 'github')
-                        @php $repos = $source->config['repositories'] ?? []; @endphp
+                        @php
+                            $repos = $source->config['repositories'] ?? [];
+                            $pausedRepos = $source->paused_repositories ?? [];
+                        @endphp
                         <div class="mt-3 pt-3 border-t border-outline-variant/20 space-y-1.5">
                             <div class="flex items-center justify-between">
                                 <span class="font-label text-[10px] text-outline uppercase tracking-wider">Repositories</span>
@@ -258,13 +285,31 @@ class extends Component {
                                     None selected · sync will fail until you pick repos
                                 </p>
                             @else
-                                <div class="flex items-center gap-1.5 flex-wrap">
+                                <ul class="divide-y divide-outline-variant/20">
                                     @foreach ($repos as $repoName)
-                                        <span class="inline-flex items-center rounded bg-surface-container-high text-on-surface-variant px-1.5 py-0.5 font-label text-[10px] tracking-wider font-mono">
-                                            {{ $repoName }}
-                                        </span>
+                                        @php $repoPaused = in_array($repoName, $pausedRepos, true); @endphp
+                                        <li wire:key="repo-{{ $source->id }}-{{ $repoName }}"
+                                            class="flex items-center justify-between gap-2 py-1.5">
+                                            <div class="flex items-center gap-1.5 min-w-0">
+                                                <span class="font-mono text-[11px] text-on-surface-variant truncate">{{ $repoName }}</span>
+                                                @if ($repoPaused)
+                                                    <span class="inline-flex items-center rounded bg-stage-stuck/20 text-stage-stuck px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
+                                                        Paused
+                                                    </span>
+                                                @else
+                                                    <span class="inline-flex items-center rounded bg-secondary-container/30 text-secondary px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
+                                                        Active
+                                                    </span>
+                                                @endif
+                                            </div>
+                                            <button type="button"
+                                                    wire:click="togglePauseRepo({{ $source->id }}, '{{ $repoName }}')"
+                                                    class="shrink-0 rounded px-2 py-0.5 font-label text-[10px] uppercase tracking-wider {{ $repoPaused ? 'bg-primary text-on-primary hover:bg-primary/90' : 'bg-surface-container-high text-on-surface hover:bg-surface-container-highest' }}">
+                                                {{ $repoPaused ? 'Resume' : 'Pause' }}
+                                            </button>
+                                        </li>
                                     @endforeach
-                                </div>
+                                </ul>
                             @endif
                         </div>
                     @endif

--- a/tests/Feature/GithubSelectReposTest.php
+++ b/tests/Feature/GithubSelectReposTest.php
@@ -163,6 +163,24 @@ class GithubSelectReposTest extends TestCase
         Http::assertNotSent(fn ($request) => str_contains((string) $request->url(), '/search/repositories'));
     }
 
+    public function test_save_prunes_orphaned_paused_repositories(): void
+    {
+        $source = $this->createGithubSourceWithToken(['repositories' => ['acme/api', 'acme/web']]);
+        $source->update(['paused_repositories' => ['acme/api', 'acme/web']]);
+
+        $this->fakeReposResponse([
+            ['full_name' => 'acme/api', 'private' => false, 'description' => null, 'updated_at' => '2026-04-10T00:00:00Z'],
+        ]);
+
+        Livewire::test('pages::github-select-repos', ['source' => $source])
+            ->call('toggle', 'acme/web')
+            ->call('save');
+
+        $source->refresh();
+        $this->assertEquals(['acme/api'], $source->config['repositories']);
+        $this->assertEquals(['acme/api'], $source->paused_repositories);
+    }
+
     public function test_non_github_source_is_rejected(): void
     {
         $source = Source::factory()->create([

--- a/tests/Feature/IssueQueueTest.php
+++ b/tests/Feature/IssueQueueTest.php
@@ -10,6 +10,7 @@ use App\Models\Source;
 use App\Services\FilterRuleService;
 use App\Services\OauthService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class IssueQueueTest extends TestCase
@@ -253,7 +254,54 @@ class IssueQueueTest extends TestCase
         $response = $this->get('/intake');
 
         $content = $response->getContent();
-        $this->assertStringNotContainsString('issues/' . Issue::first()->id . '/accept', $content);
+        $this->assertStringNotContainsString('issues/'.Issue::first()->id.'/accept', $content);
+    }
+
+    public function test_toggle_pause_repo_adds_and_removes_entry(): void
+    {
+        $source = $this->createSource([
+            'type' => SourceType::GitHub,
+            'config' => ['repositories' => ['owner/repo1', 'owner/repo2']],
+        ]);
+
+        Livewire::test('pages::intake')
+            ->call('togglePauseRepo', $source->id, 'owner/repo1');
+
+        $this->assertEquals(['owner/repo1'], $source->fresh()->paused_repositories);
+
+        Livewire::test('pages::intake')
+            ->call('togglePauseRepo', $source->id, 'owner/repo1');
+
+        $this->assertEquals([], $source->fresh()->paused_repositories);
+    }
+
+    public function test_toggle_pause_repo_ignores_repo_not_in_config(): void
+    {
+        $source = $this->createSource([
+            'type' => SourceType::GitHub,
+            'config' => ['repositories' => ['owner/repo1']],
+        ]);
+
+        Livewire::test('pages::intake')
+            ->call('togglePauseRepo', $source->id, 'owner/unknown');
+
+        $this->assertNull($source->fresh()->paused_repositories);
+    }
+
+    public function test_toggle_pause_repo_does_not_affect_source_pause(): void
+    {
+        $source = $this->createSource([
+            'type' => SourceType::GitHub,
+            'is_intake_paused' => false,
+            'config' => ['repositories' => ['owner/repo1', 'owner/repo2']],
+        ]);
+
+        Livewire::test('pages::intake')
+            ->call('togglePauseRepo', $source->id, 'owner/repo1');
+
+        $fresh = $source->fresh();
+        $this->assertFalse($fresh->is_intake_paused);
+        $this->assertEquals(['owner/repo1'], $fresh->paused_repositories);
     }
 
     public function test_labels_displayed_on_issues(): void

--- a/tests/Feature/IssueSyncTest.php
+++ b/tests/Feature/IssueSyncTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Enums\IssueStatus;
 use App\Enums\SourceType;
 use App\Jobs\SyncSourceIssuesJob;
+use App\Models\Component;
 use App\Models\FilterRule;
 use App\Models\Issue;
 use App\Models\OauthToken;
@@ -293,7 +294,7 @@ class IssueSyncTest extends TestCase
         $source = $this->createJiraSource();
         $this->createToken($source);
 
-        $existing = \App\Models\Component::create([
+        $existing = Component::create([
             'source_id' => $source->id,
             'external_id' => '500',
             'name' => 'old-name',
@@ -317,7 +318,7 @@ class IssueSyncTest extends TestCase
 
         SyncSourceIssuesJob::dispatchSync($source);
 
-        $this->assertSame(1, \App\Models\Component::where('source_id', $source->id)->count());
+        $this->assertSame(1, Component::where('source_id', $source->id)->count());
         $this->assertSame('yuvee', $existing->fresh()->name);
     }
 
@@ -566,6 +567,57 @@ class IssueSyncTest extends TestCase
         $this->assertDatabaseCount('issues', 2);
         $this->assertDatabaseHas('issues', ['external_id' => 'owner/repo1#1', 'title' => 'Repo1 issue']);
         $this->assertDatabaseHas('issues', ['external_id' => 'owner/repo2#1', 'title' => 'Repo2 issue']);
+    }
+
+    public function test_sync_skips_individually_paused_repo(): void
+    {
+        $source = $this->createGitHubSource([
+            'repositories' => ['owner/repo1', 'owner/repo2'],
+        ]);
+        $source->update(['paused_repositories' => ['owner/repo1']]);
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo1/issues*' => Http::response([
+                ['number' => 1, 'title' => 'Repo1 issue', 'body' => '', 'html_url' => 'https://github.com/owner/repo1/issues/1', 'assignee' => null, 'labels' => []],
+            ]),
+            'api.github.com/repos/owner/repo2/issues*' => Http::response([
+                ['number' => 1, 'title' => 'Repo2 issue', 'body' => '', 'html_url' => 'https://github.com/owner/repo2/issues/1', 'assignee' => null, 'labels' => []],
+            ]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $this->assertDatabaseCount('issues', 1);
+        $this->assertDatabaseMissing('issues', ['external_id' => 'owner/repo1#1']);
+        $this->assertDatabaseHas('issues', ['external_id' => 'owner/repo2#1', 'title' => 'Repo2 issue']);
+
+        Http::assertNotSent(fn ($request) => str_contains((string) $request->url(), '/repos/owner/repo1/issues'));
+    }
+
+    public function test_source_level_pause_takes_precedence_over_per_repo(): void
+    {
+        $source = $this->createGitHubSource([
+            'repositories' => ['owner/repo1', 'owner/repo2'],
+        ]);
+        $source->update([
+            'is_intake_paused' => true,
+            'paused_repositories' => [],
+        ]);
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo1/issues*' => Http::response([
+                ['number' => 1, 'title' => 'Repo1 issue', 'body' => '', 'html_url' => 'https://github.com/owner/repo1/issues/1', 'assignee' => null, 'labels' => []],
+            ]),
+            'api.github.com/repos/owner/repo2/issues*' => Http::response([
+                ['number' => 1, 'title' => 'Repo2 issue', 'body' => '', 'html_url' => 'https://github.com/owner/repo2/issues/1', 'assignee' => null, 'labels' => []],
+            ]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $this->assertDatabaseCount('issues', 0);
     }
 
     public function test_configurable_sync_interval(): void


### PR DESCRIPTION
## Summary
- Add `paused_repositories` JSON column on `sources` (per-repo pause state for GitHub sources).
- Sync job skips individually paused repos; source-level pause still short-circuits the whole source.
- Intake UI renders a per-repo Pause/Resume toggle alongside each GitHub repo and keeps the existing source-level pause button.
- Saving the repo picker now prunes orphaned entries from `paused_repositories`.

Closes #3

## Test plan
- [x] `php artisan test` (550 passed)
- [x] New tests cover: sync skips paused repo, source-level pause precedence, Livewire `togglePauseRepo` add/remove, ignores unknown repos, does not affect source pause flag, pruning orphaned entries on repo save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)