### PR TITLE
feat: detect merge conflicts and offer AI resolution

### DIFF
--- a/app/Http/Controllers/IssueViewController.php
+++ b/app/Http/Controllers/IssueViewController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\RunStatus;
 use App\Enums\StageStatus;
+use App\Jobs\ResolveConflictsJob;
 use App\Models\Run;
 use App\Models\Stage;
 use App\Services\OrchestratorService;
@@ -59,6 +60,21 @@ class IssueViewController extends Controller
 
         return redirect()->route('issues.show', $stage->run->issue)
             ->with('success', ucfirst($stage->name->value) . ' stage retrying.');
+    }
+
+    public function resolveConflicts(Run $run): RedirectResponse
+    {
+        $run->load('issue');
+
+        if (! $run->has_conflicts) {
+            return redirect()->route('issues.show', $run->issue)
+                ->with('error', 'This run has no detected conflicts.');
+        }
+
+        ResolveConflictsJob::dispatch($run);
+
+        return redirect()->route('issues.show', $run->issue)
+            ->with('success', 'Conflict resolution started. This may take a few minutes.');
     }
 
     public function guidance(Run $run, Request $request): RedirectResponse

--- a/app/Jobs/ResolveConflictsJob.php
+++ b/app/Jobs/ResolveConflictsJob.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\StageName;
+use App\Enums\StageStatus;
+use App\Models\Run;
+use App\Models\Stage;
+use App\Models\StageEvent;
+use App\Services\ImplementAgent;
+use App\Services\OrchestratorService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Dispatched when a user clicks the "Resolve" button on a run that has
+ * detected merge conflicts. Starts the merge, hands off to the Implement
+ * agent to resolve the markers, then commits + pushes the merge commit.
+ *
+ * Reuses {@see ImplementAgent} (the only AI-driven code-editing agent we
+ * have) rather than introducing a separate resolution engine.
+ */
+class ResolveConflictsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public Run $run,
+    ) {}
+
+    public function handle(ImplementAgent $implement, OrchestratorService $orchestrator): void
+    {
+        $run = $this->run->fresh(['issue.repository', 'repository', 'stages']);
+
+        if (! $run || ! $run->has_conflicts) {
+            return;
+        }
+
+        $repository = $run->repository ?? $run->issue?->repository;
+        $worktreePath = $run->worktree_path;
+
+        if (! $repository || ! $worktreePath) {
+            return;
+        }
+
+        $stage = $this->createResolutionStage($run);
+
+        $this->recordEvent($stage, 'conflict_resolution_started', 'system', [
+            'files' => $run->conflict_files ?? [],
+        ]);
+
+        try {
+            // Clear stale merge state from the last detection probe.
+            $this->abortInProgressMerge($worktreePath);
+
+            $targetBranch = $repository->default_branch ?: 'main';
+
+            $fetch = Process::path($worktreePath)
+                ->timeout(60)
+                ->run(['git', 'fetch', 'origin', $targetBranch]);
+            if (! $fetch->successful()) {
+                $this->fail($stage, $run, 'Failed to fetch target branch: ' . trim($fetch->errorOutput()));
+                return;
+            }
+
+            // Start the merge we expect to conflict.
+            $merge = Process::path($worktreePath)
+                ->timeout(60)
+                ->run(['git', 'merge', '--no-commit', '--no-ff', 'origin/' . $targetBranch]);
+
+            $conflictFiles = $this->listConflictFiles($worktreePath);
+
+            if ($merge->successful() && empty($conflictFiles)) {
+                // Merge succeeded cleanly — commit what we have and call it done.
+                $this->commitMerge($worktreePath, $targetBranch);
+                $this->pushBranch($worktreePath, $run->branch);
+                $this->markResolved($run, $stage, $conflictFiles, $orchestrator);
+                return;
+            }
+
+            $run->update(['conflict_files' => $conflictFiles]);
+
+            // Hand off to the Implement agent with a synthetic preflight doc.
+            // We mutate the in-memory Run, then attach it back to the stage so
+            // ImplementAgent (which does `$stage->run`) doesn't lazy-load a
+            // fresh copy from the DB and discard our synthetic doc.
+            $originalDoc = $run->preflight_doc;
+            $run->preflight_doc = $this->buildConflictDoc($targetBranch, $conflictFiles);
+            $stage->setRelation('run', $run);
+            $implement->execute($stage, ['resolving_conflicts' => true]);
+            $run->preflight_doc = $originalDoc;
+
+            // Verify there are no remaining conflict markers.
+            $remaining = $this->listConflictFiles($worktreePath);
+            if (! empty($remaining)) {
+                $this->abortInProgressMerge($worktreePath);
+                $this->fail($stage, $run, 'AI left unresolved conflicts: ' . implode(', ', $remaining));
+                return;
+            }
+
+            $this->commitMerge($worktreePath, $targetBranch);
+            $this->pushBranch($worktreePath, $run->branch);
+            $this->markResolved($run, $stage, $conflictFiles, $orchestrator);
+        } catch (\Throwable $e) {
+            $this->abortInProgressMerge($worktreePath);
+            $this->fail($stage, $run, 'Conflict resolution threw: ' . $e->getMessage());
+        }
+    }
+
+    private function createResolutionStage(Run $run): Stage
+    {
+        $latest = $run->stages()->latest('id')->first();
+
+        return Stage::create([
+            'run_id' => $run->id,
+            'name' => $latest?->name ?? StageName::Implement,
+            'status' => StageStatus::Running,
+            'iteration' => $latest?->iteration ?? 1,
+            'started_at' => now(),
+        ]);
+    }
+
+    private function buildConflictDoc(string $targetBranch, array $files): string
+    {
+        $list = empty($files) ? '(no files listed)' : "- " . implode("\n- ", $files);
+
+        return <<<DOC
+# Resolve Merge Conflicts
+
+You are in the middle of a merge of `origin/{$targetBranch}` into the current branch.
+The following files contain conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) that
+need to be resolved:
+
+{$list}
+
+## Instructions
+
+- For each conflicted file, read the file, understand both sides of the conflict, and
+  produce a merged version that preserves the intent of the original change on this
+  branch while incorporating any compatible changes from `{$targetBranch}`.
+- Remove all conflict markers.
+- Do NOT commit, push, or create a PR — that will happen automatically after you finish.
+- When done, call `implementation_complete` with a summary of how you resolved each
+  conflict.
+DOC;
+    }
+
+    private function listConflictFiles(string $worktreePath): array
+    {
+        $result = Process::path($worktreePath)
+            ->timeout(30)
+            ->run(['git', 'diff', '--name-only', '--diff-filter=U']);
+
+        if (! $result->successful()) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map('trim', explode("\n", $result->output())),
+            fn ($line) => $line !== '',
+        ));
+    }
+
+    private function abortInProgressMerge(string $worktreePath): void
+    {
+        $check = Process::path($worktreePath)
+            ->timeout(30)
+            ->run(['git', 'rev-parse', '-q', '--verify', 'MERGE_HEAD']);
+
+        if (! $check->successful()) {
+            return;
+        }
+
+        Process::path($worktreePath)
+            ->timeout(30)
+            ->run(['git', 'merge', '--abort']);
+    }
+
+    private function commitMerge(string $worktreePath, string $targetBranch): void
+    {
+        Process::path($worktreePath)
+            ->timeout(30)
+            ->run(['git', 'add', '-A'])
+            ->throw();
+
+        Process::path($worktreePath)
+            ->timeout(30)
+            ->run(['git', 'commit', '-m', "Merge origin/{$targetBranch} (conflicts resolved by Relay)"])
+            ->throw();
+    }
+
+    private function pushBranch(string $worktreePath, ?string $branch): void
+    {
+        if (! $branch) {
+            return;
+        }
+
+        Process::path($worktreePath)
+            ->timeout(60)
+            ->run(['git', 'push', 'origin', $branch])
+            ->throw();
+    }
+
+    private function markResolved(Run $run, Stage $stage, array $files, OrchestratorService $orchestrator): void
+    {
+        $run->update([
+            'has_conflicts' => false,
+            'conflict_detected_at' => null,
+            'conflict_files' => null,
+        ]);
+
+        $stage->update([
+            'status' => StageStatus::Completed,
+            'completed_at' => now(),
+        ]);
+
+        $this->recordEvent($stage, 'conflict_resolved', 'system', [
+            'files' => $files,
+        ]);
+
+        // Hand back to the orchestrator so the run continues normally —
+        // this clears any Stuck state and dispatches the next stage.
+        $orchestrator->restart($run->fresh());
+    }
+
+    private function fail(Stage $stage, Run $run, string $reason): void
+    {
+        $stage->update([
+            'status' => StageStatus::Failed,
+            'completed_at' => now(),
+        ]);
+
+        $this->recordEvent($stage, 'conflict_resolution_failed', 'system', [
+            'reason' => $reason,
+        ]);
+    }
+
+    private function recordEvent(Stage $stage, string $type, string $actor, array $payload = []): void
+    {
+        StageEvent::create([
+            'stage_id' => $stage->id,
+            'type' => $type,
+            'actor' => $actor,
+            'payload' => ! empty($payload) ? $payload : null,
+        ]);
+    }
+}

--- a/app/Models/Run.php
+++ b/app/Models/Run.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\RunStatus;
 use App\Enums\StuckState;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,6 +29,9 @@ class Run extends Model
         'clarification_questions',
         'clarification_answers',
         'iteration',
+        'has_conflicts',
+        'conflict_detected_at',
+        'conflict_files',
         'started_at',
         'completed_at',
     ];
@@ -41,11 +45,27 @@ class Run extends Model
             'known_facts' => 'array',
             'clarification_questions' => 'array',
             'clarification_answers' => 'array',
+            'conflict_files' => 'array',
             'stuck_unread' => 'boolean',
+            'has_conflicts' => 'boolean',
             'iteration' => 'integer',
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
+            'conflict_detected_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Runs that are still actively in the pipeline — i.e. have a
+     * worktree and should be considered for conflict detection.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereIn('status', [
+            RunStatus::Pending,
+            RunStatus::Running,
+            RunStatus::Stuck,
+        ]);
     }
 
     public function issue(): BelongsTo

--- a/app/Services/MergeConflictDetector.php
+++ b/app/Services/MergeConflictDetector.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\StageStatus;
+use App\Models\Run;
+use App\Models\StageEvent;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+class MergeConflictDetector
+{
+    /**
+     * Outcome strings returned by {@see probe()}.
+     */
+    public const OUTCOME_CLEAN = 'clean';
+
+    public const OUTCOME_CONFLICT = 'conflict';
+
+    public const OUTCOME_SKIPPED = 'skipped';
+
+    public const OUTCOME_ERROR = 'error';
+
+    private const SHELL_TIMEOUT = 60;
+
+    /**
+     * Attempt a dry-run merge of the run's target branch into its
+     * branch to detect conflicts. Always aborts the merge afterwards
+     * so the working tree is left clean.
+     *
+     * @return array{outcome: string, files?: array<string>, reason?: string}
+     */
+    public function probe(Run $run): array
+    {
+        if (! $this->isProbeable($run)) {
+            return ['outcome' => self::OUTCOME_SKIPPED, 'reason' => 'run_not_probeable'];
+        }
+
+        $repository = $run->repository ?? $run->issue?->repository;
+        if (! $repository) {
+            return ['outcome' => self::OUTCOME_SKIPPED, 'reason' => 'no_repository'];
+        }
+
+        $worktreePath = $run->worktree_path;
+        if (! $worktreePath) {
+            return ['outcome' => self::OUTCOME_SKIPPED, 'reason' => 'no_worktree'];
+        }
+
+        // Guard against probing while a stage is actively mutating the worktree.
+        $activeStage = $run->stages()
+            ->where('status', StageStatus::Running)
+            ->exists();
+        if ($activeStage) {
+            return ['outcome' => self::OUTCOME_SKIPPED, 'reason' => 'stage_running'];
+        }
+
+        $targetBranch = $repository->default_branch ?: 'main';
+
+        // Clear any stale merge state left behind by a previous probe or run.
+        $this->abortInProgressMerge($worktreePath);
+
+        // Fetch latest target — non-fatal on failure (network/auth issues).
+        $fetchResult = Process::path($worktreePath)
+            ->timeout(self::SHELL_TIMEOUT)
+            ->run(['git', 'fetch', 'origin', $targetBranch]);
+
+        if (! $fetchResult->successful()) {
+            return [
+                'outcome' => self::OUTCOME_ERROR,
+                'reason' => 'fetch_failed: ' . trim($fetchResult->errorOutput()),
+            ];
+        }
+
+        try {
+            $mergeResult = Process::path($worktreePath)
+                ->timeout(self::SHELL_TIMEOUT)
+                ->run(['git', 'merge', '--no-commit', '--no-ff', 'origin/' . $targetBranch]);
+
+            if ($mergeResult->successful()) {
+                $this->clearConflicts($run);
+
+                return ['outcome' => self::OUTCOME_CLEAN];
+            }
+
+            $files = $this->listConflictFiles($worktreePath);
+
+            if (empty($files)) {
+                // Merge failed but no conflict files — treat as error (e.g. branch missing).
+                return [
+                    'outcome' => self::OUTCOME_ERROR,
+                    'reason' => 'merge_failed: ' . trim($mergeResult->errorOutput()),
+                ];
+            }
+
+            $this->recordConflicts($run, $files);
+
+            return ['outcome' => self::OUTCOME_CONFLICT, 'files' => $files];
+        } finally {
+            $this->abortInProgressMerge($worktreePath);
+        }
+    }
+
+    /**
+     * Run detection across every active run and record stage events.
+     *
+     * @return array<int, array{run_id: int, outcome: string}>
+     */
+    public function probeAllActive(): array
+    {
+        $results = [];
+
+        Run::query()
+            ->active()
+            ->whereNotNull('worktree_path')
+            ->whereNotNull('branch')
+            ->with(['issue.repository', 'repository', 'stages'])
+            ->get()
+            ->each(function (Run $run) use (&$results) {
+                try {
+                    $result = $this->probe($run);
+                } catch (\Throwable $e) {
+                    Log::warning('MergeConflictDetector probe failed', [
+                        'run_id' => $run->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                    $result = ['outcome' => self::OUTCOME_ERROR, 'reason' => $e->getMessage()];
+                }
+
+                $results[] = ['run_id' => $run->id, 'outcome' => $result['outcome']];
+            });
+
+        return $results;
+    }
+
+    private function isProbeable(Run $run): bool
+    {
+        if ($run->status === null) {
+            return false;
+        }
+
+        $status = $run->status->value;
+
+        return in_array($status, ['pending', 'running', 'stuck'], true);
+    }
+
+    private function listConflictFiles(string $worktreePath): array
+    {
+        $result = Process::path($worktreePath)
+            ->timeout(self::SHELL_TIMEOUT)
+            ->run(['git', 'diff', '--name-only', '--diff-filter=U']);
+
+        if (! $result->successful()) {
+            return [];
+        }
+
+        $files = array_values(array_filter(
+            array_map('trim', explode("\n", $result->output())),
+            fn ($line) => $line !== '',
+        ));
+
+        return $files;
+    }
+
+    private function abortInProgressMerge(string $worktreePath): void
+    {
+        // git merge --abort errors when no merge is in progress, so guard with MERGE_HEAD check.
+        $check = Process::path($worktreePath)
+            ->timeout(self::SHELL_TIMEOUT)
+            ->run(['git', 'rev-parse', '-q', '--verify', 'MERGE_HEAD']);
+
+        if (! $check->successful()) {
+            return;
+        }
+
+        Process::path($worktreePath)
+            ->timeout(self::SHELL_TIMEOUT)
+            ->run(['git', 'merge', '--abort']);
+    }
+
+    private function recordConflicts(Run $run, array $files): void
+    {
+        $wasConflicted = (bool) $run->has_conflicts;
+
+        $run->update([
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => $files,
+        ]);
+
+        // Avoid spamming events — only log when the conflict state first appears.
+        if (! $wasConflicted) {
+            $this->recordEvent($run, 'conflict_detected', [
+                'files' => $files,
+            ]);
+        }
+    }
+
+    private function clearConflicts(Run $run): void
+    {
+        if (! $run->has_conflicts) {
+            return;
+        }
+
+        $run->update([
+            'has_conflicts' => false,
+            'conflict_detected_at' => null,
+            'conflict_files' => null,
+        ]);
+
+        $this->recordEvent($run, 'conflict_cleared', []);
+    }
+
+    private function recordEvent(Run $run, string $type, array $payload): void
+    {
+        $stage = $run->stages()->latest('id')->first();
+        if (! $stage) {
+            return;
+        }
+
+        StageEvent::create([
+            'stage_id' => $stage->id,
+            'type' => $type,
+            'actor' => 'system',
+            'payload' => ! empty($payload) ? $payload : null,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_17_000001_add_conflict_fields_to_runs_table.php
+++ b/database/migrations/2026_04_17_000001_add_conflict_fields_to_runs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->boolean('has_conflicts')->default(false)->index();
+            $table->timestamp('conflict_detected_at')->nullable();
+            $table->text('conflict_files')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->dropIndex(['has_conflicts']);
+            $table->dropColumn(['has_conflicts', 'conflict_detected_at', 'conflict_files']);
+        });
+    }
+};

--- a/resources/views/pages/⚡issue.blade.php
+++ b/resources/views/pages/⚡issue.blade.php
@@ -129,6 +129,11 @@ class extends Component
                                 @if ($listRun && $listRun->iteration > 1)
                                     <span class="text-xs text-primary">↺ {{ $listRun->iteration }}</span>
                                 @endif
+                                @if ($listRun && $listRun->has_conflicts)
+                                    <span class="inline-flex items-center rounded-full bg-error-container/40 text-error px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-widest" title="Merge conflicts detected">
+                                        Conflict
+                                    </span>
+                                @endif
                             </div>
                         </a>
                     @endforeach
@@ -365,6 +370,33 @@ class extends Component
 
                 @if ($activeIssue)
                     <div class="p-4 flex-1 overflow-y-auto">
+                        @if ($latestRun && $latestRun->has_conflicts)
+                            <div class="mb-4 rounded-md bg-error-container/30 border border-error/40 p-3">
+                                <div class="flex items-center gap-2">
+                                    <span class="inline-flex items-center rounded-full bg-error text-on-error px-2 py-0.5 font-label text-[10px] uppercase tracking-widest">
+                                        Merge Conflict
+                                    </span>
+                                    @if ($latestRun->conflict_detected_at)
+                                        <span class="text-xs text-on-surface-variant">{{ $latestRun->conflict_detected_at->diffForHumans() }}</span>
+                                    @endif
+                                </div>
+                                @if (! empty($latestRun->conflict_files))
+                                    <ul class="mt-2 text-xs text-on-surface-variant font-mono space-y-0.5">
+                                        @foreach ($latestRun->conflict_files as $file)
+                                            <li>{{ $file }}</li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                                <form method="POST" action="{{ route('issues.resolve-conflicts', $latestRun) }}" class="mt-3">
+                                    @csrf
+                                    <button type="submit" data-resolve-btn
+                                            class="w-full rounded-md bg-error px-4 py-2 text-sm font-medium text-on-error hover:bg-error/90 transition-colors">
+                                        Resolve with AI
+                                    </button>
+                                </form>
+                            </div>
+                        @endif
+
                         @if ($currentStage && $currentStage->status === \App\Enums\StageStatus::AwaitingApproval)
                             <div class="mb-4">
                                 <span class="inline-flex items-center rounded-full bg-stage-stuck/20 text-stage-stuck px-2.5 py-0.5 font-label text-[10px] uppercase tracking-widest">

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\MergeConflictDetector;
 use App\Services\MobileSyncService;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -12,3 +13,7 @@ Artisan::command('inspire', function () {
 Schedule::call(function () {
     app(MobileSyncService::class)->syncIfAppropriate();
 })->everyMinute()->name('sync-source-issues');
+
+Schedule::call(function () {
+    app(MergeConflictDetector::class)->probeAllActive();
+})->everyFiveMinutes()->name('detect-merge-conflicts')->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ Route::post('/issues/stages/{stage}/approve', [IssueViewController::class, 'appr
 Route::post('/issues/stages/{stage}/reject', [IssueViewController::class, 'reject'])->name('issues.reject-stage');
 Route::post('/issues/stages/{stage}/retry', [IssueViewController::class, 'retry'])->name('issues.retry-stage');
 Route::post('/issues/runs/{run}/guidance', [IssueViewController::class, 'guidance'])->name('issues.guidance');
+Route::post('/issues/runs/{run}/resolve-conflicts', [IssueViewController::class, 'resolveConflicts'])->name('issues.resolve-conflicts');
 
 Route::livewire('/issues/{issue}', 'pages::issue')->name('issues.show');
 Route::post('/issues/{issue}/accept', [IssueController::class, 'accept'])->name('issues.accept');

--- a/tests/Feature/IssueViewTest.php
+++ b/tests/Feature/IssueViewTest.php
@@ -12,8 +12,10 @@ use App\Models\Issue;
 use App\Models\Run;
 use App\Models\Source;
 use App\Models\Stage;
+use App\Jobs\ResolveConflictsJob;
 use App\Services\OrchestratorService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class IssueViewTest extends TestCase
@@ -269,6 +271,89 @@ class IssueViewTest extends TestCase
         $content = $response->getContent();
         $this->assertStringContainsString('grid-cols-1', $content);
         $this->assertStringContainsString('lg:grid-cols-12', $content);
+    }
+
+    public function test_conflict_badge_shown_when_run_has_conflicts(): void
+    {
+        $issue = $this->createPipelineIssue();
+        $run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Running,
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => ['src/Foo.php', 'src/Bar.php'],
+        ]);
+        Stage::factory()->create([
+            'run_id' => $run->id,
+            'name' => StageName::Implement,
+            'status' => StageStatus::Stuck,
+        ]);
+
+        $response = $this->get(route('issues.show', $issue));
+
+        $response->assertStatus(200);
+        $response->assertSee('Merge Conflict');
+        $response->assertSee('Resolve with AI');
+        $response->assertSee('src/Foo.php');
+    }
+
+    public function test_no_conflict_badge_when_run_is_clean(): void
+    {
+        $issue = $this->createPipelineIssue();
+        $run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Running,
+            'has_conflicts' => false,
+        ]);
+        Stage::factory()->create([
+            'run_id' => $run->id,
+            'name' => StageName::Implement,
+            'status' => StageStatus::Running,
+        ]);
+
+        $response = $this->get(route('issues.show', $issue));
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Resolve with AI');
+    }
+
+    public function test_resolve_conflicts_dispatches_job(): void
+    {
+        Queue::fake();
+
+        $issue = $this->createPipelineIssue();
+        $run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Running,
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => ['a.php'],
+        ]);
+
+        $response = $this->post(route('issues.resolve-conflicts', $run));
+
+        $response->assertRedirect(route('issues.show', $issue));
+        $response->assertSessionHas('success');
+        Queue::assertPushed(ResolveConflictsJob::class, function ($job) use ($run) {
+            return $job->run->id === $run->id;
+        });
+    }
+
+    public function test_resolve_conflicts_rejects_when_no_conflicts(): void
+    {
+        Queue::fake();
+
+        $issue = $this->createPipelineIssue();
+        $run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Running,
+            'has_conflicts' => false,
+        ]);
+
+        $response = $this->post(route('issues.resolve-conflicts', $run));
+
+        $response->assertSessionHas('error');
+        Queue::assertNotPushed(ResolveConflictsJob::class);
     }
 
     public function test_completed_issue_shows_completed_badge(): void

--- a/tests/Feature/MergeConflictDetectorTest.php
+++ b/tests/Feature/MergeConflictDetectorTest.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\RunStatus;
+use App\Enums\StageStatus;
+use App\Models\Issue;
+use App\Models\Repository;
+use App\Models\Run;
+use App\Models\Stage;
+use App\Models\StageEvent;
+use App\Services\MergeConflictDetector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
+
+class MergeConflictDetectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private MergeConflictDetector $detector;
+
+    private Repository $repository;
+
+    private Run $run;
+
+    private Stage $stage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->detector = new MergeConflictDetector();
+
+        $this->repository = Repository::factory()->create([
+            'path' => '/repos/my-project',
+            'default_branch' => 'main',
+            'worktree_root' => '/worktrees',
+        ]);
+
+        $issue = Issue::factory()->create(['repository_id' => $this->repository->id]);
+
+        $this->run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'repository_id' => $this->repository->id,
+            'status' => RunStatus::Running,
+            'branch' => 'relay/fix-123',
+            'worktree_path' => '/worktrees/relay-1',
+        ]);
+
+        $this->stage = Stage::factory()->create([
+            'run_id' => $this->run->id,
+            'status' => StageStatus::Pending,
+        ]);
+    }
+
+    public function test_returns_clean_when_merge_succeeds(): void
+    {
+        Process::fake([
+            '*' => Process::result(output: '', exitCode: 0),
+        ]);
+
+        $result = $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_CLEAN, $result['outcome']);
+        $this->assertFalse((bool) $this->run->fresh()->has_conflicts);
+    }
+
+    public function test_returns_conflict_and_records_files_when_merge_fails_with_unmerged_paths(): void
+    {
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'merge' && in_array('--no-commit', $process->command, true)) {
+                return Process::result(output: '', errorOutput: 'CONFLICT', exitCode: 1);
+            }
+            if (($process->command[1] ?? null) === 'diff' && in_array('--diff-filter=U', $process->command, true)) {
+                return Process::result(output: "src/foo.php\nsrc/bar.php\n", exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: 'abc123', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $result = $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_CONFLICT, $result['outcome']);
+        $this->assertEquals(['src/foo.php', 'src/bar.php'], $result['files']);
+
+        $run = $this->run->fresh();
+        $this->assertTrue($run->has_conflicts);
+        $this->assertEquals(['src/foo.php', 'src/bar.php'], $run->conflict_files);
+        $this->assertNotNull($run->conflict_detected_at);
+    }
+
+    public function test_always_aborts_merge_after_probe(): void
+    {
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: 'abc123', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        Process::assertRan(function (PendingProcess $process) {
+            return $process->command === ['git', 'merge', '--abort'];
+        });
+    }
+
+    public function test_does_not_call_abort_when_no_merge_in_progress(): void
+    {
+        // rev-parse MERGE_HEAD fails → no merge to abort.
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: '', exitCode: 1);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        Process::assertNotRan(function (PendingProcess $process) {
+            return $process->command === ['git', 'merge', '--abort'];
+        });
+    }
+
+    public function test_skips_when_no_worktree_path(): void
+    {
+        $this->run->update(['worktree_path' => null]);
+
+        Process::fake();
+
+        $result = $this->detector->probe($this->run->fresh());
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_SKIPPED, $result['outcome']);
+        $this->assertEquals('no_worktree', $result['reason']);
+        Process::assertNothingRan();
+    }
+
+    public function test_skips_when_run_is_completed(): void
+    {
+        $this->run->update(['status' => RunStatus::Completed]);
+
+        Process::fake();
+
+        $result = $this->detector->probe($this->run->fresh());
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_SKIPPED, $result['outcome']);
+        Process::assertNothingRan();
+    }
+
+    public function test_skips_when_stage_is_running(): void
+    {
+        $this->stage->update(['status' => StageStatus::Running]);
+
+        Process::fake();
+
+        $result = $this->detector->probe($this->run->fresh(['stages']));
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_SKIPPED, $result['outcome']);
+        $this->assertEquals('stage_running', $result['reason']);
+        Process::assertNothingRan();
+    }
+
+    public function test_returns_error_when_fetch_fails(): void
+    {
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'fetch') {
+                return Process::result(output: '', errorOutput: 'network unreachable', exitCode: 1);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $result = $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_ERROR, $result['outcome']);
+        $this->assertStringContainsString('fetch_failed', $result['reason']);
+        $this->assertFalse((bool) $this->run->fresh()->has_conflicts);
+    }
+
+    public function test_clears_conflict_flags_when_a_previous_conflict_is_now_clean(): void
+    {
+        $this->run->update([
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => ['src/foo.php'],
+        ]);
+
+        Process::fake([
+            '*' => Process::result(output: '', exitCode: 0),
+        ]);
+
+        $result = $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $this->assertEquals(MergeConflictDetector::OUTCOME_CLEAN, $result['outcome']);
+
+        $run = $this->run->fresh();
+        $this->assertFalse($run->has_conflicts);
+        $this->assertNull($run->conflict_detected_at);
+        $this->assertNull($run->conflict_files);
+    }
+
+    public function test_records_stage_event_on_new_conflict(): void
+    {
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'merge' && in_array('--no-commit', $process->command, true)) {
+                return Process::result(output: '', exitCode: 1);
+            }
+            if (($process->command[1] ?? null) === 'diff' && in_array('--diff-filter=U', $process->command, true)) {
+                return Process::result(output: "a.php\n", exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: 'abc', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $event = StageEvent::where('stage_id', $this->stage->id)
+            ->where('type', 'conflict_detected')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertEquals(['a.php'], $event->payload['files']);
+    }
+
+    public function test_does_not_spam_events_on_repeated_detection(): void
+    {
+        $this->run->update([
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => ['a.php'],
+        ]);
+
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'merge' && in_array('--no-commit', $process->command, true)) {
+                return Process::result(output: '', exitCode: 1);
+            }
+            if (($process->command[1] ?? null) === 'diff' && in_array('--diff-filter=U', $process->command, true)) {
+                return Process::result(output: "a.php\n", exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: 'abc', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $this->detector->probe($this->run->fresh(['issue.repository', 'repository', 'stages']));
+
+        $this->assertEquals(0, StageEvent::where('type', 'conflict_detected')->count());
+    }
+
+    public function test_probe_all_active_skips_runs_without_worktree(): void
+    {
+        Run::factory()->create([
+            'status' => RunStatus::Running,
+            'worktree_path' => null,
+            'branch' => 'relay/other',
+        ]);
+
+        Process::fake(['*' => Process::result(output: '', exitCode: 0)]);
+
+        $results = $this->detector->probeAllActive();
+
+        // Only the setUp run has a worktree path.
+        $this->assertCount(1, $results);
+        $this->assertEquals($this->run->id, $results[0]['run_id']);
+    }
+}

--- a/tests/Feature/ResolveConflictsJobTest.php
+++ b/tests/Feature/ResolveConflictsJobTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\IssueStatus;
+use App\Enums\RunStatus;
+use App\Enums\StageName;
+use App\Enums\StageStatus;
+use App\Jobs\ResolveConflictsJob;
+use App\Models\Issue;
+use App\Models\Repository;
+use App\Models\Run;
+use App\Models\Stage;
+use App\Services\ImplementAgent;
+use App\Services\OrchestratorService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ResolveConflictsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Run $run;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $repository = Repository::factory()->create([
+            'path' => '/repos/my-project',
+            'default_branch' => 'main',
+            'worktree_root' => '/worktrees',
+        ]);
+
+        $issue = Issue::factory()->create([
+            'repository_id' => $repository->id,
+            'status' => IssueStatus::InProgress,
+        ]);
+
+        $this->run = Run::factory()->create([
+            'issue_id' => $issue->id,
+            'repository_id' => $repository->id,
+            'status' => RunStatus::Stuck,
+            'branch' => 'relay/fix-123',
+            'worktree_path' => '/worktrees/relay-1',
+            'has_conflicts' => true,
+            'conflict_detected_at' => now(),
+            'conflict_files' => ['src/foo.php'],
+            'preflight_doc' => '# Original preflight',
+        ]);
+
+        Stage::factory()->create([
+            'run_id' => $this->run->id,
+            'name' => StageName::Implement,
+            'status' => StageStatus::Stuck,
+            'iteration' => 1,
+        ]);
+    }
+
+    public function test_hands_resolution_doc_to_implement_agent(): void
+    {
+        Queue::fake();
+
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                // Claim a merge is in progress so --abort is called safely.
+                return Process::result(output: 'abc', exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'merge' && in_array('--no-commit', $process->command, true)) {
+                // Real merge starts and conflicts.
+                return Process::result(output: '', errorOutput: 'CONFLICT', exitCode: 1);
+            }
+            if (($process->command[1] ?? null) === 'diff' && in_array('--diff-filter=U', $process->command, true)) {
+                // Return conflicted files on first call, none after agent resolves them.
+                static $call = 0;
+                $call++;
+                return $call === 1
+                    ? Process::result(output: "src/foo.php\n", exitCode: 0)
+                    : Process::result(output: '', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $capturedDoc = null;
+
+        $implement = $this->mock(ImplementAgent::class, function ($mock) use (&$capturedDoc) {
+            $mock->shouldReceive('execute')
+                ->once()
+                ->andReturnUsing(function (Stage $stage, array $context) use (&$capturedDoc) {
+                    $capturedDoc = $stage->run->preflight_doc;
+                });
+        });
+
+        $this->mock(OrchestratorService::class, function ($mock) {
+            $mock->shouldReceive('restart')->once();
+        });
+
+        (new ResolveConflictsJob($this->run))->handle(
+            app(ImplementAgent::class),
+            app(OrchestratorService::class),
+        );
+
+        $this->assertNotNull($capturedDoc);
+        $this->assertStringContainsString('Resolve Merge Conflicts', $capturedDoc);
+        $this->assertStringContainsString('src/foo.php', $capturedDoc);
+    }
+
+    public function test_calls_orchestrator_restart_after_clean_resolution(): void
+    {
+        Process::fake(function (PendingProcess $process) {
+            if (($process->command[1] ?? null) === 'rev-parse' && in_array('MERGE_HEAD', $process->command, true)) {
+                return Process::result(output: 'abc', exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'merge' && in_array('--no-commit', $process->command, true)) {
+                // Clean merge — no conflicts.
+                return Process::result(output: '', exitCode: 0);
+            }
+            if (($process->command[1] ?? null) === 'diff' && in_array('--diff-filter=U', $process->command, true)) {
+                return Process::result(output: '', exitCode: 0);
+            }
+            return Process::result(output: '', exitCode: 0);
+        });
+
+        $orchestrator = $this->mock(OrchestratorService::class, function ($mock) {
+            $mock->shouldReceive('restart')->once();
+        });
+
+        $this->mock(ImplementAgent::class);
+
+        (new ResolveConflictsJob($this->run))->handle(
+            app(ImplementAgent::class),
+            app(OrchestratorService::class),
+        );
+
+        $run = $this->run->fresh();
+        $this->assertFalse($run->has_conflicts);
+        $this->assertNull($run->conflict_detected_at);
+        $this->assertNull($run->conflict_files);
+    }
+
+    public function test_does_nothing_when_run_has_no_conflicts(): void
+    {
+        $this->run->update(['has_conflicts' => false]);
+
+        Process::fake();
+
+        $this->mock(ImplementAgent::class, function ($mock) {
+            $mock->shouldNotReceive('execute');
+        });
+
+        $this->mock(OrchestratorService::class, function ($mock) {
+            $mock->shouldNotReceive('restart');
+        });
+
+        (new ResolveConflictsJob($this->run))->handle(
+            app(ImplementAgent::class),
+            app(OrchestratorService::class),
+        );
+
+        Process::assertNothingRan();
+    }
+}


### PR DESCRIPTION
## Summary

- Periodic detector probes each active run's worktree with `git merge --no-commit --no-ff origin/<default>` and always aborts afterwards so the tree stays clean. Detected conflicts are recorded as `has_conflicts` + `conflict_files` + `conflict_detected_at` on the run.
- Issue card surfaces a conflict badge in the issue list and a detailed panel with a **Resolve with AI** button in the actions panel whenever `has_conflicts` is true.
- Clicking Resolve dispatches `ResolveConflictsJob` which starts the merge, hands off to the existing `ImplementAgent` with a synthetic preflight doc describing the conflicts, commits and pushes the merge commit, then calls `OrchestratorService::restart()` so the run continues normally.

## Approach notes

- `has_conflicts` is orthogonal to `RunStatus` — a run can be conflicted while Running or Stuck, so a boolean flag beats a new enum value.
- Detection skips runs with an actively Running stage to avoid racing with an in-flight agent mutating the worktree.
- `git merge --abort` is guarded by a `git rev-parse MERGE_HEAD` check, so the `finally` is a no-op on clean runs instead of erroring.
- Reuses `ImplementAgent` rather than building a separate resolution engine — the task explicitly asks to reuse what exists.

## Test plan

- [x] `tests/Feature/MergeConflictDetectorTest.php` — 12 cases: clean/conflict/error outcomes, skip conditions, abort always called, event emission and deduplication.
- [x] `tests/Feature/ResolveConflictsJobTest.php` — 3 cases: verifies the synthetic preflight doc reaches `$stage->run` at the agent handoff (previously would have been lost via lazy-load), clean-merge path, and no-op when flag is false.
- [x] `tests/Feature/IssueViewTest.php` — conflict badge rendering, Resolve button visibility, controller dispatches job and rejects when there's nothing to resolve.
- [x] Full suite: 563 passed (1372 assertions).

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)