### PR TITLE
feat: webhook intake for GitHub and Jira (#11)

### DIFF
--- a/app/Http/Controllers/GitHubWebhookController.php
+++ b/app/Http/Controllers/GitHubWebhookController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\ProcessGitHubWebhookJob;
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class GitHubWebhookController extends Controller
+{
+    public function __invoke(Request $request, Source $source): JsonResponse
+    {
+        if ($source->type->value !== 'github') {
+            return response()->json(['ok' => false, 'error' => 'source is not a github source'], 404);
+        }
+
+        $secret = $source->webhook_secret;
+
+        if (! $secret) {
+            return response()->json(['ok' => false, 'error' => 'webhook not configured'], 404);
+        }
+
+        $signature = $request->header('X-Hub-Signature-256', '');
+        $rawBody = $request->getContent();
+
+        if (! $this->verifySignature($signature, $rawBody, $secret)) {
+            return response()->json(['ok' => false, 'error' => 'invalid signature'], 401);
+        }
+
+        $event = $request->header('X-GitHub-Event', '');
+        $deliveryId = $request->header('X-GitHub-Delivery', '');
+
+        if ($deliveryId === '') {
+            return response()->json(['ok' => false, 'error' => 'missing delivery id'], 400);
+        }
+
+        $payload = $request->json()->all();
+
+        $source->update([
+            'webhook_last_delivery_at' => now(),
+            'webhook_last_error' => null,
+        ]);
+
+        if ($event === 'ping') {
+            return response()->json(['ok' => true, 'pong' => true]);
+        }
+
+        $delivery = WebhookDelivery::firstOrCreate(
+            [
+                'source_id' => $source->id,
+                'external_delivery_id' => $deliveryId,
+            ],
+            [
+                'event_type' => $event,
+                'action' => $payload['action'] ?? null,
+                'payload' => $payload,
+            ],
+        );
+
+        if ($delivery->processed_at !== null) {
+            return response()->json(['ok' => true, 'duplicate' => true]);
+        }
+
+        if (! $delivery->wasRecentlyCreated) {
+            // Re-acking an in-flight duplicate is safe; drop.
+            return response()->json(['ok' => true, 'in_flight' => true]);
+        }
+
+        if ($event !== 'issues') {
+            $delivery->update(['processed_at' => now()]);
+
+            return response()->json(['ok' => true, 'ignored' => true]);
+        }
+
+        ProcessGitHubWebhookJob::dispatch($delivery);
+
+        return response()->json(['ok' => true]);
+    }
+
+    private function verifySignature(string $header, string $rawBody, string $secret): bool
+    {
+        if (! str_starts_with($header, 'sha256=')) {
+            return false;
+        }
+
+        $expected = 'sha256='.hash_hmac('sha256', $rawBody, $secret);
+
+        return hash_equals($expected, $header);
+    }
+}

--- a/app/Http/Controllers/JiraWebhookController.php
+++ b/app/Http/Controllers/JiraWebhookController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\ProcessJiraWebhookJob;
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class JiraWebhookController extends Controller
+{
+    public function __invoke(Request $request, Source $source, string $token): JsonResponse
+    {
+        if ($source->type->value !== 'jira') {
+            return response()->json(['ok' => false, 'error' => 'source is not a jira source'], 404);
+        }
+
+        $secret = $source->webhook_secret;
+
+        if (! $secret || ! hash_equals($secret, $token)) {
+            return response()->json(['ok' => false, 'error' => 'invalid token'], 401);
+        }
+
+        $payload = $request->json()->all();
+
+        $event = $payload['webhookEvent'] ?? null;
+
+        $deliveryId = $request->header('Atlassian-Webhook-Identifier')
+            ?: $this->syntheticDeliveryId($event, $payload);
+
+        if ($deliveryId === null) {
+            return response()->json(['ok' => false, 'error' => 'missing delivery id'], 400);
+        }
+
+        $source->update([
+            'webhook_last_delivery_at' => now(),
+            'webhook_last_error' => null,
+        ]);
+
+        $delivery = WebhookDelivery::firstOrCreate(
+            [
+                'source_id' => $source->id,
+                'external_delivery_id' => $deliveryId,
+            ],
+            [
+                'event_type' => $event,
+                'action' => $payload['issue_event_type_name'] ?? null,
+                'payload' => $payload,
+            ],
+        );
+
+        if ($delivery->processed_at !== null) {
+            return response()->json(['ok' => true, 'duplicate' => true]);
+        }
+
+        if (! $delivery->wasRecentlyCreated) {
+            return response()->json(['ok' => true, 'in_flight' => true]);
+        }
+
+        $handledEvents = ['jira:issue_created', 'jira:issue_updated', 'jira:issue_deleted'];
+
+        if (! in_array($event, $handledEvents, true)) {
+            $delivery->update(['processed_at' => now()]);
+
+            return response()->json(['ok' => true, 'ignored' => true]);
+        }
+
+        ProcessJiraWebhookJob::dispatch($delivery);
+
+        return response()->json(['ok' => true]);
+    }
+
+    private function syntheticDeliveryId(?string $event, array $payload): ?string
+    {
+        $timestamp = $payload['timestamp'] ?? null;
+        $issueKey = $payload['issue']['key'] ?? $payload['issue']['id'] ?? null;
+
+        if (! $timestamp || ! $issueKey || ! $event) {
+            return null;
+        }
+
+        return hash('sha256', $event.':'.$issueKey.':'.$timestamp);
+    }
+}

--- a/app/Jobs/ProcessGitHubWebhookJob.php
+++ b/app/Jobs/ProcessGitHubWebhookJob.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Repository;
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use App\Services\GitHubClient;
+use App\Services\IssueIntakeService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessGitHubWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public WebhookDelivery $delivery,
+    ) {}
+
+    public function handle(IssueIntakeService $intake): void
+    {
+        $delivery = $this->delivery;
+        $source = $delivery->source;
+
+        if (! $source) {
+            $delivery->update(['processed_at' => now(), 'error' => 'source missing']);
+
+            return;
+        }
+
+        $payload = $delivery->payload ?? [];
+        $action = $payload['action'] ?? null;
+
+        try {
+            if ($source->is_intake_paused) {
+                $delivery->update(['processed_at' => now(), 'error' => 'source intake paused']);
+
+                return;
+            }
+
+            $repoFullName = $payload['repository']['full_name'] ?? null;
+
+            if ($repoFullName && $source->isRepositoryPaused($repoFullName)) {
+                $delivery->update(['processed_at' => now(), 'error' => 'repository paused']);
+
+                return;
+            }
+
+            $configuredRepos = $source->config['repositories'] ?? [];
+
+            if (! empty($configuredRepos) && $repoFullName && ! in_array($repoFullName, $configuredRepos, true)) {
+                $delivery->update(['processed_at' => now(), 'error' => 'repository not configured']);
+
+                return;
+            }
+
+            $ghIssue = $payload['issue'] ?? null;
+
+            if (! $ghIssue || ! $repoFullName) {
+                $delivery->update(['processed_at' => now(), 'error' => 'malformed payload']);
+
+                return;
+            }
+
+            if (GitHubClient::isPullRequest($ghIssue)) {
+                $delivery->update(['processed_at' => now(), 'error' => 'pull request ignored']);
+
+                return;
+            }
+
+            $externalId = $repoFullName.'#'.($ghIssue['number'] ?? '');
+
+            if ($action === 'deleted') {
+                $intake->markDeleted($source, $externalId);
+                $delivery->update(['processed_at' => now()]);
+
+                return;
+            }
+
+            $attrs = GitHubClient::mapToIssueAttributes($ghIssue);
+            $attrs['external_id'] = $externalId;
+            $attrs['repository_id'] = Repository::firstOrCreate(['name' => $repoFullName])->id;
+
+            $intake->upsertIssue($source, $attrs);
+
+            $delivery->update(['processed_at' => now()]);
+        } catch (\Throwable $e) {
+            $delivery->update(['processed_at' => now(), 'error' => $e->getMessage()]);
+            $source->update(['webhook_last_error' => $e->getMessage()]);
+
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/ProcessJiraWebhookJob.php
+++ b/app/Jobs/ProcessJiraWebhookJob.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\WebhookDelivery;
+use App\Services\IssueIntakeService;
+use App\Services\JiraClient;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessJiraWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public WebhookDelivery $delivery,
+    ) {}
+
+    public function handle(IssueIntakeService $intake): void
+    {
+        $delivery = $this->delivery;
+        $source = $delivery->source;
+
+        if (! $source) {
+            $delivery->update(['processed_at' => now(), 'error' => 'source missing']);
+
+            return;
+        }
+
+        $payload = $delivery->payload ?? [];
+        $event = $payload['webhookEvent'] ?? null;
+        $jiraIssue = $payload['issue'] ?? null;
+
+        try {
+            if ($source->is_intake_paused) {
+                $delivery->update(['processed_at' => now(), 'error' => 'source intake paused']);
+
+                return;
+            }
+
+            if (! $jiraIssue) {
+                $delivery->update(['processed_at' => now(), 'error' => 'malformed payload']);
+
+                return;
+            }
+
+            $externalId = (string) ($jiraIssue['key'] ?? $jiraIssue['id'] ?? '');
+
+            if ($externalId === '') {
+                $delivery->update(['processed_at' => now(), 'error' => 'missing issue key']);
+
+                return;
+            }
+
+            if ($event === 'jira:issue_deleted') {
+                $intake->markDeleted($source, $externalId);
+                $delivery->update(['processed_at' => now()]);
+
+                return;
+            }
+
+            $attrs = JiraClient::mapToIssueAttributes($jiraIssue);
+            unset($attrs['status']);
+            $attrs['component_id'] = $intake->resolveComponentId($source, $attrs);
+            unset($attrs['component_external_id'], $attrs['component_name']);
+
+            $intake->upsertIssue($source, $attrs);
+
+            $delivery->update(['processed_at' => now()]);
+        } catch (\Throwable $e) {
+            $delivery->update(['processed_at' => now(), 'error' => $e->getMessage()]);
+            $source->update(['webhook_last_error' => $e->getMessage()]);
+
+            throw $e;
+        }
+    }
+}

--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -4,12 +4,10 @@ namespace App\Jobs;
 
 use App\Enums\IssueStatus;
 use App\Enums\SourceType;
-use App\Models\Component;
-use App\Models\Issue;
 use App\Models\Repository;
 use App\Models\Source;
-use App\Services\FilterRuleService;
 use App\Services\GitHubClient;
+use App\Services\IssueIntakeService;
 use App\Services\JiraClient;
 use App\Services\OauthService;
 use Illuminate\Bus\Queueable;
@@ -26,7 +24,7 @@ class SyncSourceIssuesJob implements ShouldQueue
         public Source $source,
     ) {}
 
-    public function handle(OauthService $oauth, FilterRuleService $filterService): void
+    public function handle(OauthService $oauth, IssueIntakeService $intake): void
     {
         if ($this->isIntakePaused()) {
             return;
@@ -47,11 +45,11 @@ class SyncSourceIssuesJob implements ShouldQueue
 
             $rawIssues = match ($this->source->type) {
                 SourceType::GitHub => $this->fetchGitHubIssues($token, $oauth),
-                SourceType::Jira => $this->fetchJiraIssues($token, $oauth),
+                SourceType::Jira => $this->fetchJiraIssues($token, $oauth, $intake),
             };
 
             foreach ($rawIssues as $issueData) {
-                $this->syncIssue($issueData, $filterService);
+                $intake->upsertIssue($this->source, $issueData);
             }
 
             $this->source->update([
@@ -101,7 +99,7 @@ class SyncSourceIssuesJob implements ShouldQueue
         return $mapped;
     }
 
-    private function fetchJiraIssues($token, OauthService $oauth): array
+    private function fetchJiraIssues($token, OauthService $oauth, IssueIntakeService $intake): array
     {
         $client = new JiraClient($token, $oauth, $this->source);
         $jql = $this->buildJiraJql();
@@ -111,33 +109,12 @@ class SyncSourceIssuesJob implements ShouldQueue
         foreach ($issues as $jiraIssue) {
             $attrs = JiraClient::mapToIssueAttributes($jiraIssue);
             unset($attrs['status']);
-            $attrs['component_id'] = $this->resolveComponentId($attrs);
+            $attrs['component_id'] = $intake->resolveComponentId($this->source, $attrs);
             unset($attrs['component_external_id'], $attrs['component_name']);
             $mapped[] = $attrs;
         }
 
         return $mapped;
-    }
-
-    private function resolveComponentId(array $attrs): ?int
-    {
-        $externalId = $attrs['component_external_id'] ?? null;
-        $name = $attrs['component_name'] ?? null;
-
-        if (! $externalId) {
-            return null;
-        }
-
-        $component = Component::firstOrCreate(
-            ['source_id' => $this->source->id, 'external_id' => $externalId],
-            ['name' => $name ?? $externalId],
-        );
-
-        if ($name !== null && $component->name !== $name) {
-            $component->update(['name' => $name]);
-        }
-
-        return $component->id;
     }
 
     private function buildJiraJql(): string
@@ -170,45 +147,6 @@ class SyncSourceIssuesJob implements ShouldQueue
         $clauses[] = '('.$base.')';
 
         return implode(' AND ', $clauses).' ORDER BY updated DESC';
-    }
-
-    private function syncIssue(array $issueData, FilterRuleService $filterService): void
-    {
-        $existing = Issue::where('source_id', $this->source->id)
-            ->where('external_id', $issueData['external_id'])
-            ->first();
-
-        if ($existing) {
-            $this->updateExistingIssue($existing, $issueData);
-
-            return;
-        }
-
-        $filterService->applyToSync($issueData, $this->source);
-    }
-
-    private function updateExistingIssue(Issue $issue, array $issueData): void
-    {
-        $updatable = ['title', 'body', 'external_url', 'assignee', 'labels', 'raw_status'];
-        $changes = [];
-
-        foreach ($updatable as $field) {
-            if (array_key_exists($field, $issueData) && $issue->{$field} !== $issueData[$field]) {
-                $changes[$field] = $issueData[$field];
-            }
-        }
-
-        if ($issue->repository_id === null && ! empty($issueData['repository_id'])) {
-            $changes['repository_id'] = $issueData['repository_id'];
-        }
-
-        if (array_key_exists('component_id', $issueData) && $issue->component_id !== $issueData['component_id']) {
-            $changes['component_id'] = $issueData['component_id'];
-        }
-
-        if (! empty($changes)) {
-            $issue->update($changes);
-        }
     }
 
     private function isIntakePaused(): bool

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Str;
 
 class Source extends Model
 {
@@ -25,6 +26,9 @@ class Source extends Model
         'sync_error',
         'next_retry_at',
         'sync_interval',
+        'webhook_secret',
+        'webhook_last_delivery_at',
+        'webhook_last_error',
     ];
 
     protected function casts(): array
@@ -39,7 +43,27 @@ class Source extends Model
             'config' => 'array',
             'next_retry_at' => 'datetime',
             'sync_interval' => 'integer',
+            'webhook_secret' => 'encrypted',
+            'webhook_last_delivery_at' => 'datetime',
         ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (Source $source): void {
+            if (! $source->webhook_secret) {
+                $source->webhook_secret = Str::random(40);
+            }
+        });
+    }
+
+    public function ensureWebhookSecret(): string
+    {
+        if (! $this->webhook_secret) {
+            $this->update(['webhook_secret' => Str::random(40)]);
+        }
+
+        return $this->webhook_secret;
     }
 
     public function isRepositoryPaused(string $repoFullName): bool
@@ -65,5 +89,10 @@ class Source extends Model
     public function components(): HasMany
     {
         return $this->hasMany(Component::class);
+    }
+
+    public function webhookDeliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
     }
 }

--- a/app/Models/WebhookDelivery.php
+++ b/app/Models/WebhookDelivery.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebhookDelivery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'source_id',
+        'external_delivery_id',
+        'event_type',
+        'action',
+        'payload',
+        'processed_at',
+        'error',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'processed_at' => 'datetime',
+        ];
+    }
+
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Source::class);
+    }
+}

--- a/app/Services/IssueIntakeService.php
+++ b/app/Services/IssueIntakeService.php
@@ -38,13 +38,13 @@ class IssueIntakeService
             return null;
         }
 
-        $changes = ['raw_status' => 'deleted'];
+        $rejected = Issue::where('id', $issue->id)
+            ->where('status', IssueStatus::Queued)
+            ->update(['status' => IssueStatus::Rejected, 'raw_status' => 'deleted']);
 
-        if ($issue->status === IssueStatus::Queued) {
-            $changes['status'] = IssueStatus::Rejected;
+        if ($rejected === 0) {
+            Issue::where('id', $issue->id)->update(['raw_status' => 'deleted']);
         }
-
-        $issue->update($changes);
 
         return $issue->fresh();
     }

--- a/app/Services/IssueIntakeService.php
+++ b/app/Services/IssueIntakeService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\IssueStatus;
+use App\Models\Component;
+use App\Models\Issue;
+use App\Models\Source;
+
+class IssueIntakeService
+{
+    public function __construct(
+        private FilterRuleService $filterService,
+    ) {}
+
+    public function upsertIssue(Source $source, array $issueData): ?Issue
+    {
+        $existing = Issue::where('source_id', $source->id)
+            ->where('external_id', $issueData['external_id'])
+            ->first();
+
+        if ($existing) {
+            $this->updateExistingIssue($existing, $issueData);
+
+            return $existing->fresh();
+        }
+
+        return $this->filterService->applyToSync($issueData, $source);
+    }
+
+    public function markDeleted(Source $source, string $externalId): ?Issue
+    {
+        $issue = Issue::where('source_id', $source->id)
+            ->where('external_id', $externalId)
+            ->first();
+
+        if (! $issue) {
+            return null;
+        }
+
+        $changes = ['raw_status' => 'deleted'];
+
+        if ($issue->status === IssueStatus::Queued) {
+            $changes['status'] = IssueStatus::Rejected;
+        }
+
+        $issue->update($changes);
+
+        return $issue->fresh();
+    }
+
+    public function resolveComponentId(Source $source, array $attrs): ?int
+    {
+        $externalId = $attrs['component_external_id'] ?? null;
+        $name = $attrs['component_name'] ?? null;
+
+        if (! $externalId) {
+            return null;
+        }
+
+        $component = Component::firstOrCreate(
+            ['source_id' => $source->id, 'external_id' => $externalId],
+            ['name' => $name ?? $externalId],
+        );
+
+        if ($name !== null && $component->name !== $name) {
+            $component->update(['name' => $name]);
+        }
+
+        return $component->id;
+    }
+
+    private function updateExistingIssue(Issue $issue, array $issueData): void
+    {
+        $updatable = ['title', 'body', 'external_url', 'assignee', 'labels', 'raw_status'];
+        $changes = [];
+
+        foreach ($updatable as $field) {
+            if (array_key_exists($field, $issueData) && $issue->{$field} !== $issueData[$field]) {
+                $changes[$field] = $issueData[$field];
+            }
+        }
+
+        if ($issue->repository_id === null && ! empty($issueData['repository_id'])) {
+            $changes['repository_id'] = $issueData['repository_id'];
+        }
+
+        if (array_key_exists('component_id', $issueData) && $issue->component_id !== $issueData['component_id']) {
+            $changes['component_id'] = $issueData['component_id'];
+        }
+
+        if (! empty($changes)) {
+            $issue->update($changes);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->validateCsrfTokens(except: [
+            'webhooks/*',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/WebhookDeliveryFactory.php
+++ b/database/factories/WebhookDeliveryFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class WebhookDeliveryFactory extends Factory
+{
+    protected $model = WebhookDelivery::class;
+
+    public function definition(): array
+    {
+        return [
+            'source_id' => Source::factory(),
+            'external_delivery_id' => fake()->uuid(),
+            'event_type' => 'issues',
+            'action' => 'opened',
+            'payload' => [],
+            'processed_at' => null,
+            'error' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_17_100001_add_webhook_fields_to_sources_table.php
+++ b/database/migrations/2026_04_17_100001_add_webhook_fields_to_sources_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Source;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('sources', function (Blueprint $table) {
+            $table->text('webhook_secret')->nullable()->after('config');
+            $table->timestamp('webhook_last_delivery_at')->nullable()->after('webhook_secret');
+            $table->text('webhook_last_error')->nullable()->after('webhook_last_delivery_at');
+        });
+
+        Source::query()->whereNull('webhook_secret')->each(function (Source $source): void {
+            $source->update(['webhook_secret' => Str::random(40)]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('sources', function (Blueprint $table) {
+            $table->dropColumn(['webhook_secret', 'webhook_last_delivery_at', 'webhook_last_error']);
+        });
+    }
+};

--- a/database/migrations/2026_04_17_100002_create_webhook_deliveries_table.php
+++ b/database/migrations/2026_04_17_100002_create_webhook_deliveries_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('source_id')->constrained()->cascadeOnDelete();
+            $table->string('external_delivery_id');
+            $table->string('event_type')->nullable();
+            $table->string('action')->nullable();
+            $table->longText('payload')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->text('error')->nullable();
+            $table->timestamps();
+
+            $table->unique(['source_id', 'external_delivery_id']);
+            $table->index(['source_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_deliveries');
+    }
+};

--- a/resources/views/pages/⚡intake.blade.php
+++ b/resources/views/pages/⚡intake.blade.php
@@ -139,6 +139,8 @@ class extends Component {
     {
         $sources = Source::with('filterRule')->orderBy('name')->get();
 
+        $sources->each->ensureWebhookSecret();
+
         return [
             'sources' => $sources,
             'pausedCount' => $sources->where('is_intake_paused', true)->count(),
@@ -387,6 +389,45 @@ class extends Component {
                             @endif
                         </div>
                     @endif
+
+                    {{-- Webhook health --}}
+                    @php
+                        $webhookUrl = $source->type->value === 'github'
+                            ? route('webhooks.github', $source)
+                            : route('webhooks.jira', [$source, $source->webhook_secret]);
+                    @endphp
+                    <div class="mt-3 pt-3 border-t border-outline-variant/20 space-y-1.5">
+                        <div class="flex items-center justify-between">
+                            <span class="font-label text-[10px] text-outline uppercase tracking-wider">Webhook</span>
+                            @if ($source->webhook_last_delivery_at)
+                                <span class="font-label text-[10px] text-outline uppercase tracking-wider">
+                                    Last delivery {{ $source->webhook_last_delivery_at->diffForHumans(null, true) }} ago
+                                </span>
+                            @else
+                                <span class="font-label text-[10px] text-outline uppercase tracking-wider">Never delivered</span>
+                            @endif
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <input type="text" readonly
+                                   value="{{ $webhookUrl }}"
+                                   class="flex-1 min-w-0 bg-surface-container-high text-on-surface-variant rounded px-2 py-1 font-mono text-[10px] tracking-wider"
+                                   onclick="this.select()">
+                        </div>
+                        @if ($source->type->value === 'github')
+                            <div class="flex items-center gap-2">
+                                <span class="font-label text-[10px] text-outline uppercase tracking-wider">Secret</span>
+                                <input type="text" readonly
+                                       value="{{ $source->webhook_secret }}"
+                                       class="flex-1 min-w-0 bg-surface-container-high text-on-surface-variant rounded px-2 py-1 font-mono text-[10px] tracking-wider"
+                                       onclick="this.select()">
+                            </div>
+                        @endif
+                        @if ($source->webhook_last_error)
+                            <div class="rounded-md bg-error-container/20 border-l-2 border-error px-2 py-1.5">
+                                <p class="text-xs text-error leading-snug">{{ $source->webhook_last_error }}</p>
+                            </div>
+                        @endif
+                    </div>
 
                     {{-- Filter rules summary --}}
                     @php $rule = $source->filterRule; @endphp

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Http\Controllers\EscalationRuleController;
+use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\IssueController;
 use App\Http\Controllers\IssueViewController;
+use App\Http\Controllers\JiraWebhookController;
 use App\Http\Controllers\OauthController;
 use App\Http\Controllers\RunProgressController;
 use App\Http\Controllers\SourceController;
@@ -66,3 +68,6 @@ Route::get('/runs/{run}/progress', [RunProgressController::class, 'show'])->name
 Route::livewire('/runs/{run}/timeline', 'pages::run-timeline')->name('runs.timeline');
 
 Route::livewire('/activity', 'pages::activity')->name('activity.index');
+
+Route::post('/webhooks/github/{source}', GitHubWebhookController::class)->name('webhooks.github');
+Route::post('/webhooks/jira/{source}/{token}', JiraWebhookController::class)->name('webhooks.jira');

--- a/tests/Feature/GitHubWebhookTest.php
+++ b/tests/Feature/GitHubWebhookTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\IssueStatus;
+use App\Enums\SourceType;
+use App\Models\Issue;
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GitHubWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSource(array $config = []): Source
+    {
+        return Source::factory()->create([
+            'type' => SourceType::GitHub,
+            'external_account' => 'testuser',
+            'is_active' => true,
+            'config' => array_merge(['repositories' => ['owner/repo']], $config),
+        ]);
+    }
+
+    private function postWebhook(Source $source, string $event, array $payload, ?string $secret = null, ?string $deliveryId = null, ?string $signature = null, bool $omitDeliveryId = false): \Illuminate\Testing\TestResponse
+    {
+        $secret ??= $source->webhook_secret;
+        $deliveryId ??= 'delivery-'.fake()->uuid();
+        $body = json_encode($payload);
+        $signature ??= 'sha256='.hash_hmac('sha256', $body, $secret);
+
+        $server = [
+            'HTTP_X_GITHUB_EVENT' => $event,
+            'HTTP_X_HUB_SIGNATURE_256' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ];
+
+        if (! $omitDeliveryId) {
+            $server['HTTP_X_GITHUB_DELIVERY'] = $deliveryId;
+        }
+
+        return $this->call('POST', route('webhooks.github', $source), [], [], [], $server, $body);
+    }
+
+    private function issuesPayload(string $action = 'opened', array $overrides = []): array
+    {
+        return array_replace_recursive([
+            'action' => $action,
+            'repository' => ['full_name' => 'owner/repo'],
+            'issue' => [
+                'number' => 1,
+                'title' => 'Bug report',
+                'body' => 'Something is broken',
+                'html_url' => 'https://github.com/owner/repo/issues/1',
+                'assignee' => ['login' => 'dev1'],
+                'labels' => [['name' => 'bug']],
+            ],
+        ], $overrides);
+    }
+
+    public function test_source_created_with_webhook_secret(): void
+    {
+        $source = $this->createSource();
+
+        $this->assertNotEmpty($source->webhook_secret);
+        $this->assertEquals(40, strlen($source->webhook_secret));
+    }
+
+    public function test_webhook_rejects_invalid_signature(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload(), signature: 'sha256=deadbeef');
+
+        $response->assertStatus(401);
+        $this->assertDatabaseCount('issues', 0);
+        $this->assertDatabaseCount('webhook_deliveries', 0);
+    }
+
+    public function test_webhook_rejects_missing_delivery_id(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload(), omitDeliveryId: true);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_ping_event_is_acknowledged(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'ping', ['zen' => 'Keep it logically awesome.']);
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true, 'pong' => true]);
+        $this->assertNotNull($source->fresh()->webhook_last_delivery_at);
+    }
+
+    public function test_issue_opened_creates_issue(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload('opened'));
+
+        $response->assertOk();
+        $this->assertDatabaseHas('issues', [
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Bug report',
+            'assignee' => 'dev1',
+        ]);
+    }
+
+    public function test_issue_edited_updates_existing(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Old title',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload('edited', [
+            'issue' => ['title' => 'New title'],
+        ]));
+
+        $response->assertOk();
+        $this->assertEquals('New title', Issue::first()->title);
+    }
+
+    public function test_issue_deleted_rejects_queued_issue(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'x',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload('deleted'));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status);
+        $this->assertEquals('deleted', $issue->raw_status);
+    }
+
+    public function test_idempotency_by_delivery_id(): void
+    {
+        $source = $this->createSource();
+        $deliveryId = 'fixed-delivery-id';
+
+        $this->postWebhook($source, 'issues', $this->issuesPayload(), deliveryId: $deliveryId)->assertOk();
+        $this->postWebhook($source, 'issues', $this->issuesPayload(), deliveryId: $deliveryId)->assertOk();
+
+        $this->assertDatabaseCount('webhook_deliveries', 1);
+        $this->assertDatabaseCount('issues', 1);
+    }
+
+    public function test_paused_source_drops_event_but_acks(): void
+    {
+        $source = $this->createSource();
+        $source->update(['is_intake_paused' => true]);
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload());
+
+        $response->assertOk();
+        $this->assertDatabaseCount('issues', 0);
+        $delivery = WebhookDelivery::first();
+        $this->assertNotNull($delivery->processed_at);
+        $this->assertEquals('source intake paused', $delivery->error);
+    }
+
+    public function test_paused_repository_drops_event(): void
+    {
+        $source = $this->createSource();
+        $source->update(['paused_repositories' => ['owner/repo']]);
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload());
+
+        $response->assertOk();
+        $this->assertDatabaseCount('issues', 0);
+        $this->assertEquals('repository paused', WebhookDelivery::first()->error);
+    }
+
+    public function test_pull_request_ignored(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload('opened', [
+            'issue' => ['pull_request' => ['url' => 'x']],
+        ]));
+
+        $response->assertOk();
+        $this->assertDatabaseCount('issues', 0);
+    }
+
+    public function test_unknown_event_acked_and_skipped(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, 'issue_comment', ['action' => 'created']);
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true, 'ignored' => true]);
+        $this->assertDatabaseCount('issues', 0);
+        $this->assertNotNull(WebhookDelivery::first()->processed_at);
+    }
+
+    public function test_repository_not_in_config_is_dropped(): void
+    {
+        $source = $this->createSource(['repositories' => ['other/repo']]);
+
+        $response = $this->postWebhook($source, 'issues', $this->issuesPayload());
+
+        $response->assertOk();
+        $this->assertDatabaseCount('issues', 0);
+        $this->assertEquals('repository not configured', WebhookDelivery::first()->error);
+    }
+
+    public function test_webhook_url_shown_in_intake_ui(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->get(route('intake.index'));
+
+        $response->assertSee(route('webhooks.github', $source), false);
+        $response->assertSee($source->webhook_secret);
+    }
+
+    public function test_intake_page_backfills_missing_webhook_secret(): void
+    {
+        $source = $this->createSource();
+        $source->forceFill(['webhook_secret' => null])->saveQuietly();
+
+        $this->assertNull($source->fresh()->webhook_secret);
+
+        $this->get(route('intake.index'))->assertOk();
+
+        $this->assertNotEmpty($source->fresh()->webhook_secret);
+    }
+}

--- a/tests/Feature/IssueQueueTest.php
+++ b/tests/Feature/IssueQueueTest.php
@@ -178,7 +178,7 @@ class IssueQueueTest extends TestCase
         ]);
 
         $job = new SyncSourceIssuesJob($source);
-        $job->handle(app(OauthService::class), app(FilterRuleService::class));
+        $job->handle(app(OauthService::class), app(\App\Services\IssueIntakeService::class));
 
         $this->assertEquals(0, Issue::count());
     }
@@ -199,7 +199,7 @@ class IssueQueueTest extends TestCase
         ]);
 
         $job = new SyncSourceIssuesJob($source);
-        $job->handle(app(OauthService::class), app(FilterRuleService::class));
+        $job->handle(app(OauthService::class), app(\App\Services\IssueIntakeService::class));
 
         $this->assertEquals(2, Issue::count());
     }

--- a/tests/Feature/JiraWebhookTest.php
+++ b/tests/Feature/JiraWebhookTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\IssueStatus;
+use App\Enums\SourceType;
+use App\Models\Issue;
+use App\Models\Source;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JiraWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSource(array $config = []): Source
+    {
+        return Source::factory()->create([
+            'type' => SourceType::Jira,
+            'external_account' => 'jira-user',
+            'is_active' => true,
+            'config' => array_merge(['cloud_id' => 'test-cloud-id'], $config),
+        ]);
+    }
+
+    private function issuePayload(string $event = 'jira:issue_created', array $overrides = []): array
+    {
+        return array_replace_recursive([
+            'timestamp' => 1_712_700_000_000,
+            'webhookEvent' => $event,
+            'issue_event_type_name' => str_replace('jira:', '', $event),
+            'issue' => [
+                'id' => '10001',
+                'key' => 'TEST-1',
+                'self' => 'https://jira.example.com/issue/10001',
+                'fields' => [
+                    'summary' => 'Jira bug',
+                    'description' => null,
+                    'assignee' => ['displayName' => 'Jane'],
+                    'labels' => ['backend'],
+                    'status' => ['name' => 'To Do'],
+                ],
+            ],
+        ], $overrides);
+    }
+
+    private function postWebhook(Source $source, array $payload, ?string $token = null): \Illuminate\Testing\TestResponse
+    {
+        $token ??= $source->webhook_secret;
+
+        return $this->postJson(route('webhooks.jira', [$source, $token]), $payload);
+    }
+
+    public function test_rejects_invalid_token(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, $this->issuePayload(), token: 'wrong-token');
+
+        $response->assertStatus(401);
+        $this->assertDatabaseCount('issues', 0);
+    }
+
+    public function test_issue_created_creates_issue(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_created'));
+
+        $response->assertOk();
+        $this->assertDatabaseHas('issues', [
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'Jira bug',
+            'assignee' => 'Jane',
+            'raw_status' => 'To Do',
+        ]);
+    }
+
+    public function test_issue_updated_updates_existing(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'Old',
+            'status' => IssueStatus::Queued,
+            'raw_status' => 'To Do',
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_updated', [
+            'issue' => ['fields' => ['summary' => 'New', 'status' => ['name' => 'In Progress']]],
+        ]));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals('New', $issue->title);
+        $this->assertEquals('In Progress', $issue->raw_status);
+    }
+
+    public function test_issue_deleted_rejects_queued_issue(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_deleted'));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status);
+    }
+
+    public function test_idempotency_via_synthetic_delivery_id(): void
+    {
+        $source = $this->createSource();
+
+        $this->postWebhook($source, $this->issuePayload())->assertOk();
+        $this->postWebhook($source, $this->issuePayload())->assertOk();
+
+        $this->assertDatabaseCount('webhook_deliveries', 1);
+        $this->assertDatabaseCount('issues', 1);
+    }
+
+    public function test_idempotency_via_atlassian_header(): void
+    {
+        $source = $this->createSource();
+
+        $this->withHeaders(['Atlassian-Webhook-Identifier' => 'hook-abc'])
+            ->postJson(route('webhooks.jira', [$source, $source->webhook_secret]), $this->issuePayload())
+            ->assertOk();
+
+        $this->withHeaders(['Atlassian-Webhook-Identifier' => 'hook-abc'])
+            ->postJson(route('webhooks.jira', [$source, $source->webhook_secret]), $this->issuePayload('jira:issue_created', [
+                'timestamp' => 1_712_700_999_999,
+            ]))
+            ->assertOk();
+
+        $this->assertDatabaseCount('webhook_deliveries', 1);
+    }
+
+    public function test_paused_source_drops_event(): void
+    {
+        $source = $this->createSource();
+        $source->update(['is_intake_paused' => true]);
+
+        $response = $this->postWebhook($source, $this->issuePayload());
+
+        $response->assertOk();
+        $this->assertDatabaseCount('issues', 0);
+        $this->assertEquals('source intake paused', WebhookDelivery::first()->error);
+    }
+
+    public function test_unknown_event_acked_and_skipped(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->postWebhook($source, $this->issuePayload('comment_created'));
+
+        $response->assertOk();
+        $response->assertJson(['ok' => true, 'ignored' => true]);
+        $this->assertDatabaseCount('issues', 0);
+    }
+
+    public function test_webhook_url_shown_in_intake_ui(): void
+    {
+        $source = $this->createSource();
+
+        $response = $this->get(route('intake.index'));
+
+        $response->assertSee(route('webhooks.jira', [$source, $source->webhook_secret]), false);
+    }
+}


### PR DESCRIPTION
Closes #11 (partially — see deferred below).

## Summary

Adds realtime webhook intake so issue events update the board immediately instead of waiting for the next scheduled sync. Polling stays as the reconciliation fallback.

- `POST /webhooks/github/{source}` — verifies `X-Hub-Signature-256` (timing-safe HMAC), dedupes on `X-GitHub-Delivery`, handles `issues` events (opened/edited/closed/reopened/deleted). Acks `ping`.
- `POST /webhooks/jira/{source}/{token}` — verifies URL token against `Source.webhook_secret`, dedupes on `Atlassian-Webhook-Identifier` or synthetic `event+key+timestamp` hash. Handles `jira:issue_created/updated/deleted`.
- Each `Source` gets a 40-char `webhook_secret` on creation; migration backfills existing rows; intake page lazily ensures it.
- `webhook_deliveries` table for idempotency + health surface (unique `(source_id, external_delivery_id)`).
- Intake UI shows webhook URL, secret (GitHub), last delivery, last error per source.
- Shared `IssueIntakeService` replaces duplicate upsert logic — `SyncSourceIssuesJob` and both webhook jobs go through it, so filter rules / auto-accept behavior stay consistent.

## Design decisions worth flagging

- **Paused sources ack with 200 and drop internally.** Non-2xx causes both GitHub and Jira to retry aggressively — ack-and-drop is the correct interpretation of "drop events for paused scopes" from the issue. `webhook_deliveries.error` records why.
- **Jira token in URL path.** Standard for self-hosted / Jira Cloud without signing. Worth knowing that path segments can land in webserver access logs.
- **`issue_comment`, `pull_request`, `push` events** are acked but not processed. `pull_request`/`push` tie to runs, which the issue calls out as out-of-scope. `issue_comment` is in-scope per issue but deferred — cheap follow-up since no schema changes.
- **Jira transitions** are covered implicitly via `jira:issue_updated` (the payload carries the new status in `fields.status.name`).

## Deferred to follow-up

- **Automated webhook registration** via `POST /repos/{owner}/{repo}/hooks` and Jira REST API. Intake page currently exposes URL + secret for manual configuration. #11 can stay open for this, or split to #11a.
- **"Send test event" UI action** — synthetic `ping` with valid signature. Small.
- **`issue_comment` processing.**

## Test plan

- [x] `composer test` — 593 passing
- [x] GitHub: signature verification, idempotency (same delivery id → no duplicate row), paused source / paused repository / unconfigured repo all ack-drop, PR filtering, `ping`, `deleted` marks queued issue as `rejected` with `raw_status='deleted'`
- [x] Jira: invalid token → 401, `jira:issue_created/updated/deleted`, idempotency via header + synthetic id, paused source, unknown event ignored
- [x] Intake UI shows webhook URL for both provider types; backfill works for pre-existing sources with null secret
- [ ] Manual verification against a real GitHub/Jira webhook delivery — leaving for the reviewer since it requires ngrok + a real source

🤖 Generated with [Claude Code](https://claude.com/claude-code)