### PR TITLE
feat: add "Other — explain" escape hatch to preflight choice questions (#23)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -949,7 +949,7 @@ parameters:
 			path: tests/Feature/PreflightAgentTest.php
 
 		-
-			message: '#^Property App\\Contracts\\AiProvider@anonymous/tests/Feature/PreflightAgentTest\.php\:357\:\:\$captured is never read, only written\.$#'
+			message: '#^Property App\\Contracts\\AiProvider@anonymous/(?:[^:]+/)?PreflightAgentTest\.php\:357\:\:\$captured is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1
 			path: tests/Feature/PreflightAgentTest.php

--- a/resources/views/pages/⚡preflight-clarification.blade.php
+++ b/resources/views/pages/⚡preflight-clarification.blade.php
@@ -10,10 +10,15 @@ use Livewire\Component;
 new
 #[Title('Preflight Clarification')]
 #[Layout('layouts::app')]
-class extends Component {
+class extends Component
+{
+    public const OTHER_SENTINEL = '__other__';
+
     public Run $run;
 
     public array $answers = [];
+
+    public array $otherText = [];
 
     public function mount(): void
     {
@@ -28,6 +33,7 @@ class extends Component {
 
         foreach ($this->run->clarification_questions ?? [] as $q) {
             $this->answers[$q['id']] = '';
+            $this->otherText[$q['id']] = '';
         }
     }
 
@@ -38,13 +44,30 @@ class extends Component {
             return $this->redirectRoute('intake.index', navigate: true);
         }
 
-        $answers = array_filter($this->answers, fn ($v) => $v !== null && $v !== '');
+        $answers = $this->normalizeAnswers();
         $this->run->update(['clarification_answers' => $answers]);
         $orchestrator->resume($stage);
 
         session()->flash('success', "Answers submitted for \"{$this->run->issue->title}\". Preflight resuming.");
 
         return $this->redirectRoute('intake.index', navigate: true);
+    }
+
+    private function normalizeAnswers(): array
+    {
+        $normalized = [];
+
+        foreach ($this->answers as $id => $value) {
+            if ($value === self::OTHER_SENTINEL) {
+                $value = trim($this->otherText[$id] ?? '');
+            }
+
+            if ($value !== null && $value !== '') {
+                $normalized[$id] = $value;
+            }
+        }
+
+        return $normalized;
     }
 
     public function skipToDoc(OrchestratorService $orchestrator)
@@ -117,12 +140,25 @@ class extends Component {
                             @foreach ($question['options'] as $option)
                                 <label class="flex items-center gap-2 text-sm text-on-surface-variant">
                                     <input type="radio"
-                                           wire:model="answers.{{ $question['id'] }}"
+                                           wire:model.live="answers.{{ $question['id'] }}"
                                            value="{{ $option }}"
                                            class="text-primary">
                                     {{ $option }}
                                 </label>
                             @endforeach
+                            <label class="flex items-center gap-2 text-sm text-on-surface-variant">
+                                <input type="radio"
+                                       wire:model.live="answers.{{ $question['id'] }}"
+                                       value="__other__"
+                                       class="text-primary">
+                                <span>Other — explain</span>
+                            </label>
+                            @if (($answers[$question['id']] ?? '') === '__other__')
+                                <textarea wire:model="otherText.{{ $question['id'] }}"
+                                          rows="3"
+                                          placeholder="Describe the answer none of the options captured…"
+                                          class="mt-2 w-full rounded-md bg-surface-container-lowest border-outline-variant text-on-surface px-3 py-2 text-sm focus:border-primary focus:ring-primary"></textarea>
+                            @endif
                         </div>
                     @else
                         <textarea wire:model="answers.{{ $question['id'] }}"

--- a/tests/Feature/PreflightAgentTest.php
+++ b/tests/Feature/PreflightAgentTest.php
@@ -499,6 +499,87 @@ class PreflightAgentTest extends TestCase
         $this->assertArrayNotHasKey('q2', $run->clarification_answers);
     }
 
+    public function test_show_clarification_page_renders_other_option_for_choice(): void
+    {
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+        $run->update([
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which auth provider?', 'type' => 'choice', 'options' => ['OAuth', 'Local']],
+            ],
+        ]);
+
+        $response = $this->get(route('preflight.show', $run));
+
+        $response->assertOk();
+        $response->assertSee('Other — explain');
+    }
+
+    public function test_submit_answers_with_other_persists_free_text(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+        $run->update([
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which dashboard?', 'type' => 'choice', 'options' => ['Admin', 'User']],
+            ],
+        ]);
+
+        Livewire::test('pages::preflight-clarification', ['run' => $run])
+            ->set('answers.q1', '__other__')
+            ->set('otherText.q1', 'Operations console we built in-house')
+            ->call('submitAnswers')
+            ->assertRedirect(route('intake.index'));
+
+        $run->refresh();
+        $this->assertEquals('Operations console we built in-house', $run->clarification_answers['q1']);
+        Queue::assertPushed(ExecuteStageJob::class);
+    }
+
+    public function test_submit_answers_with_other_and_empty_text_drops_answer(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+        $run->update([
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which dashboard?', 'type' => 'choice', 'options' => ['Admin', 'User']],
+                ['id' => 'q2', 'text' => 'Any constraints?', 'type' => 'text'],
+            ],
+        ]);
+
+        Livewire::test('pages::preflight-clarification', ['run' => $run])
+            ->set('answers.q1', '__other__')
+            ->set('otherText.q1', '   ')
+            ->set('answers.q2', 'Must use React')
+            ->call('submitAnswers');
+
+        $run->refresh();
+        $this->assertArrayNotHasKey('q1', $run->clarification_answers);
+        $this->assertEquals('Must use React', $run->clarification_answers['q2']);
+    }
+
+    public function test_submit_answers_canonical_choice_is_unaffected_by_other_text(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+        $run->update([
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which dashboard?', 'type' => 'choice', 'options' => ['Admin', 'User']],
+            ],
+        ]);
+
+        Livewire::test('pages::preflight-clarification', ['run' => $run])
+            ->set('answers.q1', 'Admin')
+            ->set('otherText.q1', 'should be ignored')
+            ->call('submitAnswers');
+
+        $run->refresh();
+        $this->assertEquals('Admin', $run->clarification_answers['q1']);
+    }
+
     public function test_submit_answers_redirects_when_no_pending_stage(): void
     {
         [$issue, $run, $stage] = $this->setupRunWithStage();


### PR DESCRIPTION
Closes #23.

## Summary
- Every choice-type clarification question now renders a final **\"Other — explain\"** radio with a `__other__` sentinel value.
- When that option is selected, a textarea appears wired to `otherText.{id}`; the free-text replaces the sentinel in `clarification_answers` at submit time.
- Blank / whitespace-only free-text drops the answer (same behaviour as an empty free-text answer), so users can't accidentally persist `__other__` as the answer.
- No agent-side changes — `PreflightAgent` already consumes `clarification_answers` as free-text strings.

## Test plan
- [x] `php artisan test --filter=PreflightAgentTest` — 27 pass (4 new).
- [x] `php artisan test` — 826 pass, 0 fail.
- [x] `vendor/bin/phpstan analyse` — clean (full + per-file mode).
- [x] `vendor/bin/pint --dirty` — clean.
- [ ] Manual: open an ambiguous issue whose Preflight produced multi-choice questions, pick \"Other — explain\", type a reply, submit → answer persisted verbatim; resume kicks in.

## Notes
- Minor baseline touch: relaxed the existing ignore entry for the anonymous `AiProvider` class in `PreflightAgentTest` so it matches both the full-project and per-file phpstan invocations (lint-staged runs per-file; phpstan strips the `tests/Feature/` prefix from anonymous-class identifiers in that mode). Not my code; unrelated to the feature.
- Larger redesign (`in_app` vs `on_issue` clarification channels, structured question types, bounded rounds) is tracked in #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)