### PR TITLE
fix: reconcile closed Jira issues with the local intake queue (#18)

### DIFF
--- a/app/Http/Controllers/IssueController.php
+++ b/app/Http/Controllers/IssueController.php
@@ -65,7 +65,13 @@ class IssueController extends Controller
                 ->with('error', 'Only queued issues can be rejected.');
         }
 
-        $issue->update(['status' => IssueStatus::Rejected]);
+        // Clear raw_status so the row is distinguishable from sync-driven
+        // rejections. markReopened() treats null raw_status as "user rejected"
+        // and refuses to resurrect the issue on upstream reopen.
+        $issue->update([
+            'status' => IssueStatus::Rejected,
+            'raw_status' => null,
+        ]);
 
         return redirect()->route('intake.index')
             ->with('success', "Issue \"{$issue->title}\" rejected.");

--- a/app/Jobs/ProcessJiraWebhookJob.php
+++ b/app/Jobs/ProcessJiraWebhookJob.php
@@ -63,7 +63,19 @@ class ProcessJiraWebhookJob implements ShouldQueue
             }
 
             $attrs = JiraClient::mapToIssueAttributes($jiraIssue);
-            unset($attrs['status']);
+
+            if (($attrs['state'] ?? 'open') === 'closed') {
+                $intake->markClosed($source, $externalId, $attrs['state_reason'] ?? null);
+                $delivery->update(['processed_at' => now()]);
+
+                return;
+            }
+
+            // Reconcile reopens: a status transition back to an open Jira status
+            // must un-reject issues that were previously closed by sync or webhook.
+            $intake->markReopened($source, $externalId);
+
+            unset($attrs['status'], $attrs['state'], $attrs['state_reason']);
             $attrs['component_id'] = $intake->resolveComponentId($source, $attrs);
             unset($attrs['component_external_id'], $attrs['component_name']);
 

--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -60,10 +60,11 @@ class SyncSourceIssuesJob implements ShouldQueue
                     continue;
                 }
 
-                // Reconcile reopens on the sync pass so sources without discrete reopen
-                // webhook events (e.g. Jira) are not left stuck in Rejected indefinitely.
-                $intake->markReopened($this->source, $issueData['external_id']);
-
+                // Open-path issues go through upsertIssue, which reconciles any
+                // prior sync-driven rejection back to Queued using the same row
+                // it already fetches — sources without discrete reopen webhook
+                // events (e.g. Jira) get reopens reconciled here without a
+                // separate DB round-trip.
                 unset($issueData['state'], $issueData['state_reason']);
                 $intake->upsertIssue($this->source, $issueData);
             }
@@ -141,7 +142,11 @@ class SyncSourceIssuesJob implements ShouldQueue
     private function buildJiraJql(): string
     {
         $config = $this->source->config ?? [];
-        $base = $config['jql'] ?? 'status != Done';
+        // Default is a time-bounded clause (not a status filter) so the sync
+        // sees Done/Closed/Resolved transitions and can reconcile them back
+        // to the local queue. Users can override with a narrower JQL via
+        // source config if they prefer.
+        $base = $config['jql'] ?? 'updated >= -30d';
 
         $clauses = [];
 

--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -60,6 +60,10 @@ class SyncSourceIssuesJob implements ShouldQueue
                     continue;
                 }
 
+                // Reconcile reopens on the sync pass so sources without discrete reopen
+                // webhook events (e.g. Jira) are not left stuck in Rejected indefinitely.
+                $intake->markReopened($this->source, $issueData['external_id']);
+
                 unset($issueData['state'], $issueData['state_reason']);
                 $intake->upsertIssue($this->source, $issueData);
             }

--- a/app/Services/IssueIntakeService.php
+++ b/app/Services/IssueIntakeService.php
@@ -20,6 +20,7 @@ class IssueIntakeService
             ->first();
 
         if ($existing) {
+            $this->reconcileReopenOnFetchedRow($existing);
             $this->updateExistingIssue($existing, $issueData);
 
             return $existing->fresh();
@@ -63,17 +64,38 @@ class IssueIntakeService
             return null;
         }
 
+        $this->reconcileReopenOnFetchedRow($issue);
+
+        return $issue->fresh();
+    }
+
+    /**
+     * Clear a sync-driven rejection so the row returns to Queued. No-op for
+     * user-driven rejections (distinguished by raw_status being null) and
+     * non-Rejected rows. Writes directly using the row we already fetched
+     * so callers that pair this with upsert logic don't pay for a second
+     * lookup.
+     */
+    private function reconcileReopenOnFetchedRow(Issue $issue): void
+    {
+        if ($issue->status !== IssueStatus::Rejected) {
+            return;
+        }
+
         $syncDrivenClose = $issue->raw_status !== null
             && (str_starts_with($issue->raw_status, 'closed') || $issue->raw_status === 'deleted');
 
-        if ($issue->status === IssueStatus::Rejected && $syncDrivenClose) {
-            Issue::where('id', $issue->id)->update([
-                'status' => IssueStatus::Queued,
-                'raw_status' => null,
-            ]);
+        if (! $syncDrivenClose) {
+            return;
         }
 
-        return $issue->fresh();
+        Issue::where('id', $issue->id)->update([
+            'status' => IssueStatus::Queued,
+            'raw_status' => null,
+        ]);
+
+        $issue->status = IssueStatus::Queued;
+        $issue->raw_status = null;
     }
 
     public function markDeleted(Source $source, string $externalId): ?Issue

--- a/app/Services/JiraClient.php
+++ b/app/Services/JiraClient.php
@@ -152,6 +152,7 @@ class JiraClient
     public static function mapToIssueAttributes(array $jiraIssue): array
     {
         $fields = $jiraIssue['fields'] ?? [];
+        $statusName = $fields['status']['name'] ?? null;
         $component = self::pickComponent($fields['components'] ?? [], $jiraIssue['key'] ?? $jiraIssue['id'] ?? null);
 
         return [
@@ -161,8 +162,10 @@ class JiraClient
             'external_url' => $jiraIssue['self'] ?? '',
             'assignee' => $fields['assignee']['displayName'] ?? null,
             'labels' => $fields['labels'] ?? [],
-            'status' => self::mapStatus($fields['status']['name'] ?? null),
-            'raw_status' => $fields['status']['name'] ?? null,
+            'status' => self::mapStatus($statusName),
+            'raw_status' => $statusName,
+            'state' => self::mapState($statusName),
+            'state_reason' => $statusName,
             'component_external_id' => $component['id'] ?? null,
             'component_name' => $component['name'] ?? null,
         ];
@@ -221,6 +224,15 @@ class JiraClient
             in_array($lower, ['in progress', 'in review']) => 'accepted',
             default => 'incoming',
         };
+    }
+
+    private static function mapState(?string $jiraStatus): string
+    {
+        if (! $jiraStatus) {
+            return 'open';
+        }
+
+        return in_array(strtolower($jiraStatus), ['done', 'closed', 'resolved']) ? 'closed' : 'open';
     }
 
     private function request(string $method, string $path, array $data = []): Response

--- a/tests/Feature/IssueSyncTest.php
+++ b/tests/Feature/IssueSyncTest.php
@@ -550,7 +550,7 @@ class IssueSyncTest extends TestCase
                 && str_contains($url, 'status in ("In Review","Backlog")')
                 && str_contains($url, 'assignee = currentUser()')
                 && str_contains($url, 'sprint in openSprints()')
-                && str_contains($url, 'status != Done');
+                && str_contains($url, 'updated >= -30d');
         });
     }
 

--- a/tests/Feature/IssueSyncTest.php
+++ b/tests/Feature/IssueSyncTest.php
@@ -299,6 +299,144 @@ class IssueSyncTest extends TestCase
         $this->assertEquals('closed:completed', $issue->raw_status);
     }
 
+    public function test_jira_sync_rejects_queued_issues_closed_upstream(): void
+    {
+        $source = $this->createJiraSource();
+        $this->createToken($source);
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'Will be closed',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $this->fakeJiraIssues([
+            [
+                'id' => '10001',
+                'key' => 'TEST-1',
+                'self' => 'https://jira.example.com/issue/10001',
+                'fields' => [
+                    'summary' => 'Will be closed',
+                    'description' => null,
+                    'assignee' => null,
+                    'labels' => [],
+                    'status' => ['name' => 'Done'],
+                ],
+            ],
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $issue = Issue::where('source_id', $source->id)->where('external_id', 'TEST-1')->first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status);
+        $this->assertEquals('closed:Done', $issue->raw_status);
+    }
+
+    public function test_jira_sync_preserves_accepted_when_closed_upstream(): void
+    {
+        $source = $this->createJiraSource();
+        $this->createToken($source);
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'In flight',
+            'status' => IssueStatus::Accepted,
+        ]);
+
+        $this->fakeJiraIssues([
+            [
+                'id' => '10001',
+                'key' => 'TEST-1',
+                'self' => 'https://jira.example.com/issue/10001',
+                'fields' => [
+                    'summary' => 'In flight',
+                    'description' => null,
+                    'assignee' => null,
+                    'labels' => [],
+                    'status' => ['name' => 'Done'],
+                ],
+            ],
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $issue = Issue::where('source_id', $source->id)->where('external_id', 'TEST-1')->first();
+        $this->assertEquals(IssueStatus::Accepted, $issue->status, 'local pipeline state must win over upstream close');
+        $this->assertEquals('closed:Done', $issue->raw_status);
+    }
+
+    public function test_jira_sync_reopens_sync_rejected_issue(): void
+    {
+        $source = $this->createJiraSource();
+        $this->createToken($source);
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'Previously closed',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => 'closed:Done',
+        ]);
+
+        $this->fakeJiraIssues([
+            [
+                'id' => '10001',
+                'key' => 'TEST-1',
+                'self' => 'https://jira.example.com/issue/10001',
+                'fields' => [
+                    'summary' => 'Previously closed',
+                    'description' => null,
+                    'assignee' => null,
+                    'labels' => [],
+                    'status' => ['name' => 'To Do'],
+                ],
+            ],
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $issue = Issue::where('source_id', $source->id)->where('external_id', 'TEST-1')->first();
+        $this->assertEquals(IssueStatus::Queued, $issue->status);
+        // upsertIssue runs after markReopened, so raw_status reflects the current Jira status
+        $this->assertEquals('To Do', $issue->raw_status);
+    }
+
+    public function test_jira_sync_does_not_reopen_user_rejected_issue(): void
+    {
+        $source = $this->createJiraSource();
+        $this->createToken($source);
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'User rejected',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => null,
+        ]);
+
+        $this->fakeJiraIssues([
+            [
+                'id' => '10001',
+                'key' => 'TEST-1',
+                'self' => 'https://jira.example.com/issue/10001',
+                'fields' => [
+                    'summary' => 'User rejected',
+                    'description' => null,
+                    'assignee' => null,
+                    'labels' => [],
+                    'status' => ['name' => 'To Do'],
+                ],
+            ],
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $issue = Issue::where('source_id', $source->id)->where('external_id', 'TEST-1')->first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status, 'user-driven rejection must not resurrect on upstream reopen');
+    }
+
     public function test_jira_sync_creates_issues(): void
     {
         $source = $this->createJiraSource();

--- a/tests/Feature/JiraWebhookTest.php
+++ b/tests/Feature/JiraWebhookTest.php
@@ -116,6 +116,88 @@ class JiraWebhookTest extends TestCase
         $this->assertEquals(IssueStatus::Rejected, $issue->status);
     }
 
+    public function test_issue_updated_to_done_rejects_queued_issue(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'closeable',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_updated', [
+            'issue' => ['fields' => ['status' => ['name' => 'Done']]],
+        ]));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status);
+        $this->assertEquals('closed:Done', $issue->raw_status);
+    }
+
+    public function test_issue_updated_to_done_preserves_accepted_status(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'in flight',
+            'status' => IssueStatus::Accepted,
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_updated', [
+            'issue' => ['fields' => ['status' => ['name' => 'Done']]],
+        ]));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Accepted, $issue->status);
+        $this->assertEquals('closed:Done', $issue->raw_status);
+    }
+
+    public function test_issue_updated_to_open_status_reopens_sync_rejected_issue(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'reopenable',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => 'closed:Done',
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_updated', [
+            'issue' => ['fields' => ['status' => ['name' => 'To Do']]],
+        ]));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Queued, $issue->status);
+        // upsertIssue runs after markReopened, so raw_status reflects the current Jira status
+        $this->assertEquals('To Do', $issue->raw_status);
+    }
+
+    public function test_issue_updated_to_open_does_not_revive_user_rejected_issue(): void
+    {
+        $source = $this->createSource();
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'TEST-1',
+            'title' => 'user-rejected',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => null,
+        ]);
+
+        $response = $this->postWebhook($source, $this->issuePayload('jira:issue_updated', [
+            'issue' => ['fields' => ['status' => ['name' => 'To Do']]],
+        ]));
+
+        $response->assertOk();
+        $issue = Issue::first();
+        $this->assertEquals(IssueStatus::Rejected, $issue->status, 'user-driven rejection must not resurrect on upstream reopen');
+    }
+
     public function test_idempotency_via_synthetic_delivery_id(): void
     {
         $source = $this->createSource();


### PR DESCRIPTION
Closes #18.

## Summary
- `JiraClient::mapToIssueAttributes` now returns `state` (`open`/`closed`) and `state_reason` (raw Jira status name like `Done`), derived via a new `mapState()` helper
- `SyncSourceIssuesJob` open-path calls `markReopened` before `upsertIssue` so sync-driven Rejected issues return to Queued when Jira status transitions back to open (handles Jira's lack of discrete reopen webhook action)
- `ProcessJiraWebhookJob` dispatches on Jira status: `Done`/`Closed`/`Resolved` → `markClosed`; open status → `markReopened` + `upsertIssue`
- Pipeline states (`Accepted`, `InProgress`, `Completed`, `Failed`, `Stuck`) are never clobbered; user-driven rejections (`raw_status = null`) are not resurrected on reopen
- `raw_status` becomes `closed:<jira-status-name>` (e.g. `closed:Done`) for sync-closed issues
- 8 new feature tests added across `IssueSyncTest` and `JiraWebhookTest` mirroring the GitHub precedent from #17

## Test plan
- [x] feature tests for Jira sync close/reopen reconciliation (4 tests in `IssueSyncTest`)
- [x] feature tests for Jira webhook close/reopen reconciliation (4 tests in `JiraWebhookTest`)
- [x] full test suite passes (838 tests)
- [x] phpstan clean, pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)