### PR TITLE
feat: detect repository framework on connect and sync (#16)

### DIFF
--- a/app/Enums/FrameworkSource.php
+++ b/app/Enums/FrameworkSource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum FrameworkSource: string
+{
+    case Payload = 'payload';
+    case Ai = 'ai';
+    case Manual = 'manual';
+}

--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -6,6 +6,7 @@ use App\Enums\IssueStatus;
 use App\Enums\SourceType;
 use App\Models\Repository;
 use App\Models\Source;
+use App\Services\FrameworkDetector;
 use App\Services\GitHubClient;
 use App\Services\GitHubWebhookManager;
 use App\Services\IssueIntakeService;
@@ -26,10 +27,11 @@ class SyncSourceIssuesJob implements ShouldQueue
         public Source $source,
     ) {}
 
-    public function handle(OauthService $oauth, IssueIntakeService $intake, ?GitHubWebhookManager $webhookManager = null, ?JiraWebhookManager $jiraWebhookManager = null): void
+    public function handle(OauthService $oauth, IssueIntakeService $intake, ?GitHubWebhookManager $webhookManager = null, ?JiraWebhookManager $jiraWebhookManager = null, ?FrameworkDetector $frameworkDetector = null): void
     {
         $webhookManager ??= app(GitHubWebhookManager::class);
         $jiraWebhookManager ??= app(JiraWebhookManager::class);
+        $frameworkDetector ??= app(FrameworkDetector::class);
 
         if ($this->isIntakePaused()) {
             return;
@@ -49,7 +51,7 @@ class SyncSourceIssuesJob implements ShouldQueue
             $token = $oauth->refreshIfExpired($token);
 
             $rawIssues = match ($this->source->type) {
-                SourceType::GitHub => $this->fetchGitHubIssues($token, $oauth, $webhookManager),
+                SourceType::GitHub => $this->fetchGitHubIssues($token, $oauth, $webhookManager, $frameworkDetector),
                 SourceType::Jira => $this->fetchJiraIssues($token, $oauth, $intake, $jiraWebhookManager),
             };
 
@@ -74,7 +76,7 @@ class SyncSourceIssuesJob implements ShouldQueue
         }
     }
 
-    private function fetchGitHubIssues($token, OauthService $oauth, GitHubWebhookManager $webhookManager): array
+    private function fetchGitHubIssues($token, OauthService $oauth, GitHubWebhookManager $webhookManager, FrameworkDetector $frameworkDetector): array
     {
         $client = new GitHubClient($token, $oauth);
         $repos = $this->source->config['repositories'] ?? [];
@@ -96,6 +98,8 @@ class SyncSourceIssuesJob implements ShouldQueue
             $repository = Repository::firstOrCreate(
                 ['name' => $repoFullName],
             );
+
+            $frameworkDetector->detect($client, $repository, $owner, $repo);
 
             $issues = $client->allIssues($owner, $repo);
 

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\FrameworkSource;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -19,6 +20,12 @@ class Repository extends Model
         'setup_script',
         'teardown_script',
         'run_script',
+        'framework',
+        'framework_source',
+    ];
+
+    protected $casts = [
+        'framework_source' => FrameworkSource::class,
     ];
 
     public function issues(): HasMany

--- a/app/Services/FrameworkDetector.php
+++ b/app/Services/FrameworkDetector.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\FrameworkSource;
+use App\Models\Repository;
+use App\Services\AiProviders\AiProviderManager;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class FrameworkDetector
+{
+    /**
+     * Allowed framework slugs. AI output is coerced to one of these; unknowns → 'other'.
+     *
+     * @var list<string>
+     */
+    public const ALLOWED = [
+        'laravel',
+        'rails',
+        'django',
+        'nextjs',
+        'nestjs',
+        'flask',
+        'fastapi',
+        'go-echo',
+        'go-gin',
+        'springboot',
+        'other',
+    ];
+
+    private const MANIFESTS = [
+        'composer.json',
+        'package.json',
+        'pyproject.toml',
+        'Gemfile',
+        'go.mod',
+        'Cargo.toml',
+    ];
+
+    public function __construct(
+        private AiProviderManager $providerManager,
+    ) {}
+
+    /**
+     * Detect and persist the framework for a repository.
+     *
+     * Detection order (cheapest first):
+     *   1. GitHub `language` + topics.
+     *   2. Manifest file probe via contents API.
+     *   3. AI fallback via the configured provider.
+     *
+     * Skipped entirely when `framework_source === Manual` — the user's choice is
+     * authoritative and must never be clobbered by sync-driven detection.
+     */
+    public function detect(GitHubClient $client, Repository $repository, string $owner, string $repo): void
+    {
+        if ($repository->framework_source === FrameworkSource::Manual) {
+            return;
+        }
+
+        try {
+            $repoMeta = $client->getRepo($owner, $repo);
+        } catch (Throwable $e) {
+            Log::warning('Framework detection failed to fetch repo metadata', [
+                'repository_id' => $repository->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $payloadHit = $this->detectFromPayload($repoMeta);
+
+        if ($payloadHit !== null) {
+            $this->persist($repository, $payloadHit, FrameworkSource::Payload);
+
+            return;
+        }
+
+        $manifestHit = $this->detectFromManifests($client, $owner, $repo);
+
+        if ($manifestHit !== null) {
+            $this->persist($repository, $manifestHit, FrameworkSource::Payload);
+
+            return;
+        }
+
+        $aiHit = $this->detectWithAi($repoMeta);
+
+        if ($aiHit !== null) {
+            $this->persist($repository, $aiHit, FrameworkSource::Ai);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $repoMeta
+     */
+    private function detectFromPayload(array $repoMeta): ?string
+    {
+        $language = strtolower((string) ($repoMeta['language'] ?? ''));
+        $topics = array_map(
+            fn ($t) => strtolower((string) $t),
+            is_array($repoMeta['topics'] ?? null) ? $repoMeta['topics'] : [],
+        );
+
+        foreach (self::ALLOWED as $slug) {
+            if ($slug !== 'other' && in_array($slug, $topics, true)) {
+                return $slug;
+            }
+        }
+
+        $topicMap = [
+            'rails' => ['ruby-on-rails'],
+            'nextjs' => ['next', 'next-js', 'next.js'],
+            'nestjs' => ['nest', 'nest-js', 'nest.js'],
+            'springboot' => ['spring-boot', 'spring'],
+            'fastapi' => ['fast-api'],
+        ];
+
+        foreach ($topicMap as $slug => $aliases) {
+            foreach ($aliases as $alias) {
+                if (in_array($alias, $topics, true)) {
+                    return $slug;
+                }
+            }
+        }
+
+        if ($language === 'php' && in_array('laravel', $topics, true)) {
+            return 'laravel';
+        }
+
+        if ($language === 'ruby' && in_array('rails', $topics, true)) {
+            return 'rails';
+        }
+
+        return null;
+    }
+
+    private function detectFromManifests(GitHubClient $client, string $owner, string $repo): ?string
+    {
+        $manifests = [];
+
+        foreach (self::MANIFESTS as $path) {
+            try {
+                $contents = $client->getFileContents($owner, $repo, $path);
+            } catch (Throwable $e) {
+                continue;
+            }
+
+            if ($contents !== null) {
+                $manifests[$path] = $contents;
+            }
+        }
+
+        if (isset($manifests['composer.json'])) {
+            $hit = $this->classifyComposer($manifests['composer.json']);
+            if ($hit !== null) {
+                return $hit;
+            }
+        }
+
+        if (isset($manifests['package.json'])) {
+            $hit = $this->classifyPackageJson($manifests['package.json']);
+            if ($hit !== null) {
+                return $hit;
+            }
+        }
+
+        if (isset($manifests['pyproject.toml'])) {
+            $hit = $this->classifyPyproject($manifests['pyproject.toml']);
+            if ($hit !== null) {
+                return $hit;
+            }
+        }
+
+        if (isset($manifests['Gemfile'])) {
+            $hit = $this->classifyGemfile($manifests['Gemfile']);
+            if ($hit !== null) {
+                return $hit;
+            }
+        }
+
+        if (isset($manifests['go.mod'])) {
+            $hit = $this->classifyGoMod($manifests['go.mod']);
+            if ($hit !== null) {
+                return $hit;
+            }
+        }
+
+        return null;
+    }
+
+    private function classifyComposer(string $contents): ?string
+    {
+        try {
+            $json = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_array($json)) {
+            return null;
+        }
+
+        $require = array_merge(
+            is_array($json['require'] ?? null) ? $json['require'] : [],
+            is_array($json['require-dev'] ?? null) ? $json['require-dev'] : [],
+        );
+
+        if (isset($require['laravel/framework'])) {
+            return 'laravel';
+        }
+
+        return null;
+    }
+
+    private function classifyPackageJson(string $contents): ?string
+    {
+        try {
+            $json = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_array($json)) {
+            return null;
+        }
+
+        $deps = array_merge(
+            is_array($json['dependencies'] ?? null) ? $json['dependencies'] : [],
+            is_array($json['devDependencies'] ?? null) ? $json['devDependencies'] : [],
+        );
+
+        if (isset($deps['next'])) {
+            return 'nextjs';
+        }
+
+        if (isset($deps['@nestjs/core']) || isset($deps['@nestjs/common'])) {
+            return 'nestjs';
+        }
+
+        return null;
+    }
+
+    private function classifyPyproject(string $contents): ?string
+    {
+        $lower = strtolower($contents);
+
+        if (str_contains($lower, 'django')) {
+            return 'django';
+        }
+
+        if (str_contains($lower, 'fastapi')) {
+            return 'fastapi';
+        }
+
+        if (str_contains($lower, 'flask')) {
+            return 'flask';
+        }
+
+        return null;
+    }
+
+    private function classifyGemfile(string $contents): ?string
+    {
+        if (preg_match('/^\s*gem\s+["\']rails["\']/mi', $contents) === 1) {
+            return 'rails';
+        }
+
+        return null;
+    }
+
+    private function classifyGoMod(string $contents): ?string
+    {
+        if (str_contains($contents, 'github.com/labstack/echo')) {
+            return 'go-echo';
+        }
+
+        if (str_contains($contents, 'github.com/gin-gonic/gin')) {
+            return 'go-gin';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $repoMeta
+     */
+    private function detectWithAi(array $repoMeta): ?string
+    {
+        try {
+            $provider = $this->providerManager->resolve();
+        } catch (Throwable $e) {
+            Log::warning('Framework detection AI fallback skipped — no provider available', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $allowed = implode(', ', self::ALLOWED);
+        $language = (string) ($repoMeta['language'] ?? 'unknown');
+        $topics = is_array($repoMeta['topics'] ?? null) ? implode(', ', $repoMeta['topics']) : '';
+        $description = (string) ($repoMeta['description'] ?? '');
+
+        $system = "You classify source-code repositories by primary framework. Respond with exactly one slug from this allowlist (no punctuation, no explanation): {$allowed}.";
+        $user = "Repository metadata:\nLanguage: {$language}\nTopics: {$topics}\nDescription: {$description}\n\nReturn the single best-matching slug.";
+
+        try {
+            $result = $provider->chat([
+                ['role' => 'system', 'content' => $system],
+                ['role' => 'user', 'content' => $user],
+            ], [], ['max_tokens' => 32]);
+        } catch (Throwable $e) {
+            Log::warning('Framework detection AI call failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $raw = is_string($result['content'] ?? null) ? $result['content'] : '';
+
+        return $this->coerceAllowed($raw);
+    }
+
+    private function coerceAllowed(string $raw): string
+    {
+        $slug = trim(strtolower($raw));
+        $slug = preg_replace('/[^a-z0-9\-]/', '', $slug) ?? '';
+
+        if ($slug === '') {
+            return 'other';
+        }
+
+        foreach (self::ALLOWED as $allowed) {
+            if ($slug === $allowed) {
+                return $allowed;
+            }
+        }
+
+        return 'other';
+    }
+
+    private function persist(Repository $repository, string $framework, FrameworkSource $source): void
+    {
+        $repository->forceFill([
+            'framework' => $framework,
+            'framework_source' => $source,
+        ])->save();
+    }
+}

--- a/app/Services/GitHubClient.php
+++ b/app/Services/GitHubClient.php
@@ -74,6 +74,47 @@ class GitHubClient
         ])->json();
     }
 
+    /**
+     * Fetch repository metadata (language, topics, default_branch, etc.).
+     *
+     * @return array<string, mixed>
+     */
+    public function getRepo(string $owner, string $repo): array
+    {
+        return $this->request('get', "/repos/{$owner}/{$repo}", [], [
+            'Accept' => 'application/vnd.github.mercy-preview+json',
+        ])->json();
+    }
+
+    /**
+     * Fetch the raw, decoded contents of a single file at the repo's default branch.
+     * Returns null when the file does not exist (404) or when the response cannot be decoded.
+     */
+    public function getFileContents(string $owner, string $repo, string $path): ?string
+    {
+        $response = $this->request(
+            'get',
+            "/repos/{$owner}/{$repo}/contents/{$path}",
+            [],
+            [],
+            allowNotFound: true,
+        );
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        $body = $response->json();
+
+        if (! is_array($body) || ($body['encoding'] ?? null) !== 'base64' || ! isset($body['content'])) {
+            return null;
+        }
+
+        $decoded = base64_decode(str_replace("\n", '', (string) $body['content']), true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
     public function listRepositoryWebhooks(string $owner, string $repo): array
     {
         return $this->request('get', "/repos/{$owner}/{$repo}/hooks")->json();
@@ -166,14 +207,20 @@ class GitHubClient
         return $all;
     }
 
-    private function request(string $method, string $path, array $data = []): Response
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, string>  $extraHeaders
+     */
+    private function request(string $method, string $path, array $data = [], array $extraHeaders = [], bool $allowNotFound = false): Response
     {
         $url = self::BASE_URL.$path;
 
         $this->token = $this->oauth->refreshIfExpired($this->token);
 
+        $headers = array_merge(['Accept' => 'application/vnd.github+json'], $extraHeaders);
+
         $pending = Http::withToken($this->token->access_token)
-            ->withHeaders(['Accept' => 'application/vnd.github+json']);
+            ->withHeaders($headers);
 
         $response = $method === 'get'
             ? $pending->get($url, $data)
@@ -182,7 +229,7 @@ class GitHubClient
         if ($response->status() === 401 && $this->token->refresh_token) {
             $this->token = $this->oauth->refreshToken($this->token);
             $pending = Http::withToken($this->token->access_token)
-                ->withHeaders(['Accept' => 'application/vnd.github+json']);
+                ->withHeaders($headers);
             $response = $method === 'get'
                 ? $pending->get($url, $data)
                 : $pending->$method($url, $data);
@@ -191,7 +238,11 @@ class GitHubClient
         if ($response->status() === 403 && $this->isRateLimited($response)) {
             $this->waitForRateLimit($response);
 
-            return $this->request($method, $path, $data);
+            return $this->request($method, $path, $data, $extraHeaders, $allowNotFound);
+        }
+
+        if ($allowNotFound && $response->status() === 404) {
+            return $response;
         }
 
         $response->throw();

--- a/database/factories/RepositoryFactory.php
+++ b/database/factories/RepositoryFactory.php
@@ -19,6 +19,8 @@ class RepositoryFactory extends Factory
             'setup_script' => null,
             'teardown_script' => null,
             'run_script' => null,
+            'framework' => null,
+            'framework_source' => null,
         ];
     }
 }

--- a/database/migrations/2026_04_18_151033_add_framework_to_repositories_table.php
+++ b/database/migrations/2026_04_18_151033_add_framework_to_repositories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->string('framework')->nullable()->after('run_script');
+            $table->string('framework_source')->nullable()->after('framework');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->dropColumn(['framework', 'framework_source']);
+        });
+    }
+};

--- a/resources/views/pages/⚡intake.blade.php
+++ b/resources/views/pages/⚡intake.blade.php
@@ -1,11 +1,13 @@
 <?php
 
+use App\Enums\FrameworkSource;
 use App\Enums\IssueStatus;
 use App\Jobs\SyncSourceIssuesJob;
 use App\Models\Issue;
 use App\Models\OauthToken;
 use App\Models\Repository;
 use App\Models\Source;
+use App\Services\FrameworkDetector;
 use App\Services\GitHubClient;
 use App\Services\JiraClient;
 use App\Services\OauthService;
@@ -24,6 +26,47 @@ class extends Component
 
     /** source id → flash message for the last sync-now call */
     public array $syncResults = [];
+
+    /** "sourceId-repoFullName" → currently-editing flag */
+    public array $editingFramework = [];
+
+    public function startEditFramework(int $sourceId, string $repoFullName): void
+    {
+        $this->editingFramework[$sourceId.'-'.$repoFullName] = true;
+    }
+
+    public function cancelEditFramework(int $sourceId, string $repoFullName): void
+    {
+        unset($this->editingFramework[$sourceId.'-'.$repoFullName]);
+    }
+
+    public function saveFramework(int $sourceId, string $repoFullName, string $framework): void
+    {
+        $source = Source::findOrFail($sourceId);
+
+        if ($source->type->value !== 'github') {
+            return;
+        }
+
+        $repos = $source->config['repositories'] ?? [];
+        if (! in_array($repoFullName, $repos, true)) {
+            return;
+        }
+
+        if (! in_array($framework, FrameworkDetector::ALLOWED, true)) {
+            session()->flash('error', 'Unknown framework slug.');
+
+            return;
+        }
+
+        $repository = Repository::firstOrCreate(['name' => $repoFullName]);
+        $repository->forceFill([
+            'framework' => $framework,
+            'framework_source' => FrameworkSource::Manual,
+        ])->save();
+
+        unset($this->editingFramework[$sourceId.'-'.$repoFullName]);
+    }
 
     public function togglePause(int $sourceId): void
     {
@@ -148,10 +191,18 @@ class extends Component
 
         $sources->each->ensureWebhookSecret();
 
+        $repoNames = $sources->flatMap(fn (Source $s) => $s->type->value === 'github'
+            ? ($s->config['repositories'] ?? [])
+            : [])->unique()->values()->all();
+
+        $repositoriesByName = Repository::whereIn('name', $repoNames)->get()->keyBy('name');
+
         return [
             'sources' => $sources,
             'pausedCount' => $sources->where('is_intake_paused', true)->count(),
             'connectedCount' => $sources->where('is_active', true)->count(),
+            'repositoriesByName' => $repositoriesByName,
+            'frameworkOptions' => FrameworkDetector::ALLOWED,
             'incoming' => Issue::with(['source', 'component.repositories', 'repository'])
                 ->where('status', IssueStatus::Queued)
                 ->orderByDesc('created_at')
@@ -296,26 +347,64 @@ class extends Component
                             @else
                                 <ul class="divide-y divide-outline-variant/20">
                                     @foreach ($repos as $repoName)
-                                        @php $repoPaused = in_array($repoName, $pausedRepos, true); @endphp
+                                        @php
+                                            $repoPaused = in_array($repoName, $pausedRepos, true);
+                                            $repoModel = $repositoriesByName[$repoName] ?? null;
+                                            $editKey = $source->id.'-'.$repoName;
+                                            $isEditingFramework = ! empty($editingFramework[$editKey]);
+                                        @endphp
                                         <li wire:key="repo-{{ $source->id }}-{{ $repoName }}"
-                                            class="flex items-center justify-between gap-2 py-1.5">
-                                            <div class="flex items-center gap-1.5 min-w-0">
-                                                <span class="font-mono text-[11px] text-on-surface-variant truncate">{{ $repoName }}</span>
-                                                @if ($repoPaused)
-                                                    <span class="inline-flex items-center rounded bg-stage-stuck/20 text-stage-stuck px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
-                                                        Paused
-                                                    </span>
+                                            class="flex flex-col gap-1 py-1.5">
+                                            <div class="flex items-center justify-between gap-2">
+                                                <div class="flex items-center gap-1.5 min-w-0">
+                                                    <span class="font-mono text-[11px] text-on-surface-variant truncate">{{ $repoName }}</span>
+                                                    @if ($repoPaused)
+                                                        <span class="inline-flex items-center rounded bg-stage-stuck/20 text-stage-stuck px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
+                                                            Paused
+                                                        </span>
+                                                    @else
+                                                        <span class="inline-flex items-center rounded bg-secondary-container/30 text-secondary px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
+                                                            Active
+                                                        </span>
+                                                    @endif
+                                                </div>
+                                                <button type="button"
+                                                        wire:click="togglePauseRepo({{ $source->id }}, '{{ $repoName }}')"
+                                                        class="shrink-0 rounded px-2 py-0.5 font-label text-[10px] uppercase tracking-wider {{ $repoPaused ? 'bg-primary text-on-primary hover:bg-primary/90' : 'bg-surface-container-high text-on-surface hover:bg-surface-container-highest' }}">
+                                                    {{ $repoPaused ? 'Resume' : 'Pause' }}
+                                                </button>
+                                            </div>
+                                            <div class="flex items-center gap-1.5">
+                                                @if ($isEditingFramework)
+                                                    <span class="font-label text-[10px] text-outline uppercase tracking-wider">Stack</span>
+                                                    <select wire:change="saveFramework({{ $source->id }}, '{{ $repoName }}', $event.target.value)"
+                                                            class="bg-surface-container-high text-on-surface rounded px-1.5 py-0.5 font-label text-[10px] uppercase tracking-wider"
+                                                            data-testid="framework-select-{{ $source->id }}-{{ $repoName }}">
+                                                        <option value="">— choose —</option>
+                                                        @foreach ($frameworkOptions as $option)
+                                                            <option value="{{ $option }}" @if ($repoModel?->framework === $option) selected @endif>{{ $option }}</option>
+                                                        @endforeach
+                                                    </select>
+                                                    <button type="button"
+                                                            wire:click="cancelEditFramework({{ $source->id }}, '{{ $repoName }}')"
+                                                            class="font-label text-[10px] text-outline uppercase tracking-wider hover:underline">Cancel</button>
                                                 @else
-                                                    <span class="inline-flex items-center rounded bg-secondary-container/30 text-secondary px-1.5 py-0.5 font-label text-[9px] uppercase tracking-wider shrink-0">
-                                                        Active
+                                                    <span class="inline-flex items-center rounded bg-surface-container-high text-on-surface-variant px-1.5 py-0.5 font-label text-[10px] uppercase tracking-wider shrink-0">
+                                                        Stack: {{ $repoModel?->framework ?? '—' }}
                                                     </span>
+                                                    @if ($repoModel?->framework_source)
+                                                        <span class="font-label text-[9px] text-outline uppercase tracking-wider">
+                                                            ({{ $repoModel->framework_source->value }})
+                                                        </span>
+                                                    @endif
+                                                    <button type="button"
+                                                            wire:click="startEditFramework({{ $source->id }}, '{{ $repoName }}')"
+                                                            class="font-label text-[10px] text-primary uppercase tracking-wider hover:underline"
+                                                            aria-label="Edit stack for {{ $repoName }}">
+                                                        Edit
+                                                    </button>
                                                 @endif
                                             </div>
-                                            <button type="button"
-                                                    wire:click="togglePauseRepo({{ $source->id }}, '{{ $repoName }}')"
-                                                    class="shrink-0 rounded px-2 py-0.5 font-label text-[10px] uppercase tracking-wider {{ $repoPaused ? 'bg-primary text-on-primary hover:bg-primary/90' : 'bg-surface-container-high text-on-surface hover:bg-surface-container-highest' }}">
-                                                {{ $repoPaused ? 'Resume' : 'Pause' }}
-                                            </button>
                                         </li>
                                     @endforeach
                                 </ul>

--- a/tests/Feature/FrameworkDetectionTest.php
+++ b/tests/Feature/FrameworkDetectionTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Contracts\AiProvider;
+use App\Enums\FrameworkSource;
+use App\Enums\SourceType;
+use App\Enums\StageName;
+use App\Jobs\SyncSourceIssuesJob;
+use App\Models\OauthToken;
+use App\Models\Repository;
+use App\Models\Source;
+use App\Services\AiProviders\AiProviderManager;
+use App\Services\FrameworkDetector;
+use App\Services\GitHubClient;
+use App\Services\OauthService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FrameworkDetectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createGitHubSource(array $config = []): Source
+    {
+        return Source::factory()->create([
+            'type' => SourceType::GitHub,
+            'external_account' => 'testuser',
+            'is_active' => true,
+            'config' => array_merge(['repositories' => ['owner/repo']], $config),
+        ]);
+    }
+
+    private function createToken(Source $source): OauthToken
+    {
+        OauthToken::factory()->create([
+            'source_id' => $source->id,
+            'provider' => $source->type->value,
+            'access_token' => 'test-token',
+            'expires_at' => now()->addHour(),
+        ]);
+
+        return OauthToken::where('source_id', $source->id)->firstOrFail();
+    }
+
+    /**
+     * Base64-encoded GitHub contents API response body for a single file.
+     */
+    private function contentsResponse(string $raw): array
+    {
+        return [
+            'type' => 'file',
+            'encoding' => 'base64',
+            'content' => base64_encode($raw),
+            'path' => 'placeholder',
+        ];
+    }
+
+    private function bindAiProvider(?string $reply): void
+    {
+        $fakeProvider = new class($reply) implements AiProvider
+        {
+            public function __construct(private ?string $reply) {}
+
+            public function chat(array $messages, array $tools = [], array $options = []): array
+            {
+                return [
+                    'content' => $this->reply,
+                    'tool_calls' => [],
+                    'usage' => ['input_tokens' => 0, 'output_tokens' => 0],
+                    'raw' => [],
+                ];
+            }
+
+            public function stream(array $messages, array $tools = [], array $options = []): \Generator
+            {
+                yield ['type' => 'message', 'content' => $this->reply, 'tool_calls' => null, 'usage' => null];
+            }
+        };
+
+        $fakeManager = new class($fakeProvider) extends AiProviderManager
+        {
+            public function __construct(private AiProvider $provider) {}
+
+            public function resolve(?string $workspaceId = null, ?StageName $stage = null): AiProvider
+            {
+                return $this->provider;
+            }
+        };
+
+        $this->app->instance(AiProviderManager::class, $fakeManager);
+    }
+
+    public function test_detects_laravel_from_composer_manifest(): void
+    {
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            // Repo metadata returns ambiguous language so that payload-only step 1 misses.
+            'api.github.com/repos/owner/repo' => Http::response([
+                'language' => null,
+                'topics' => [],
+                'description' => '',
+            ]),
+            'api.github.com/repos/owner/repo/contents/composer.json' => Http::response(
+                $this->contentsResponse(json_encode([
+                    'require' => ['laravel/framework' => '^12.0'],
+                ]))
+            ),
+            'api.github.com/repos/owner/repo/contents/*' => Http::response(null, 404),
+            'api.github.com/repos/owner/repo/issues*' => Http::response([]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+        $this->assertSame('laravel', $repository->framework);
+        $this->assertSame(FrameworkSource::Payload, $repository->framework_source);
+    }
+
+    public function test_ai_fallback_invoked_when_payload_and_manifests_ambiguous(): void
+    {
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo' => Http::response([
+                'language' => null,
+                'topics' => [],
+                'description' => '',
+            ]),
+            // Every manifest returns 404
+            'api.github.com/repos/owner/repo/contents/*' => Http::response(null, 404),
+            'api.github.com/repos/owner/repo/issues*' => Http::response([]),
+        ]);
+
+        $this->bindAiProvider('nextjs');
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+        $this->assertSame('nextjs', $repository->framework);
+        $this->assertSame(FrameworkSource::Ai, $repository->framework_source);
+    }
+
+    public function test_ai_output_outside_allowlist_is_coerced_to_other(): void
+    {
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo' => Http::response([
+                'language' => null,
+                'topics' => [],
+                'description' => '',
+            ]),
+            'api.github.com/repos/owner/repo/contents/*' => Http::response(null, 404),
+            'api.github.com/repos/owner/repo/issues*' => Http::response([]),
+        ]);
+
+        $this->bindAiProvider('something-weird');
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+        $this->assertSame('other', $repository->framework);
+        $this->assertSame(FrameworkSource::Ai, $repository->framework_source);
+    }
+
+    public function test_manual_override_is_not_overwritten_by_detection(): void
+    {
+        Repository::factory()->create([
+            'name' => 'owner/repo',
+            'framework' => 'django',
+            'framework_source' => FrameworkSource::Manual,
+        ]);
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+
+        // Provider manager must not be reached; bind one that would throw if called.
+        $this->bindAiProvider('laravel');
+
+        $detector = app(FrameworkDetector::class);
+
+        // Stub a GitHub client that would return laravel-looking payload if asked.
+        $source = $this->createGitHubSource();
+        $token = $this->createToken($source);
+        $oauth = app(OauthService::class);
+        $client = new GitHubClient($token, $oauth);
+
+        // No HTTP fakes → if detect() tried to call the API it would fail. The
+        // manual-source early-return guarantees we never reach the network.
+        Http::fake([
+            '*' => Http::response('should-not-be-called', 500),
+        ]);
+
+        $detector->detect($client, $repository, 'owner', 'repo');
+
+        $repository->refresh();
+        $this->assertSame('django', $repository->framework);
+        $this->assertSame(FrameworkSource::Manual, $repository->framework_source);
+        Http::assertNothingSent();
+    }
+
+    public function test_manual_edit_via_livewire_persists_and_flags_source_manual(): void
+    {
+        $source = $this->createGitHubSource();
+
+        Livewire::test('pages::intake')
+            ->call('saveFramework', $source->id, 'owner/repo', 'rails')
+            ->assertOk();
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+        $this->assertSame('rails', $repository->framework);
+        $this->assertSame(FrameworkSource::Manual, $repository->framework_source);
+    }
+
+    public function test_detects_nextjs_from_package_json(): void
+    {
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo' => Http::response([
+                'language' => 'JavaScript',
+                'topics' => [],
+                'description' => '',
+            ]),
+            'api.github.com/repos/owner/repo/contents/composer.json' => Http::response(null, 404),
+            'api.github.com/repos/owner/repo/contents/package.json' => Http::response(
+                $this->contentsResponse(json_encode([
+                    'dependencies' => ['next' => '^14.0.0', 'react' => '^18.0.0'],
+                ]))
+            ),
+            'api.github.com/repos/owner/repo/contents/*' => Http::response(null, 404),
+            'api.github.com/repos/owner/repo/issues*' => Http::response([]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        $repository = Repository::where('name', 'owner/repo')->firstOrFail();
+        $this->assertSame('nextjs', $repository->framework);
+        $this->assertSame(FrameworkSource::Payload, $repository->framework_source);
+    }
+}


### PR DESCRIPTION
## Summary
- Detects a primary framework for each connected GitHub repository so downstream agents (Preflight/Implement/Verify) can tailor prompts to the stack.
- Adds `framework` + `framework_source` columns on `repositories` with a new `FrameworkSource` enum (`payload`, `ai`, `manual`).
- Introduces `App\Services\FrameworkDetector`, wired into `SyncSourceIssuesJob::fetchGitHubIssues` — runs once per repo per sync, respects `manual` overrides and never clobbers them.
- Surfaces a `Stack: <framework>` badge + inline selector on each repo entry within the intake source card. Editing flips `framework_source` to `manual`.

## Detection order
1. Repo payload: GitHub `language` + `topics` (high-confidence map, plus common aliases like `ruby-on-rails`, `next.js`, `spring-boot`).
2. Manifest probe via GitHub contents API: `composer.json` (→ `laravel` when `laravel/framework` is required), `package.json` (→ `nextjs`/`nestjs`), `pyproject.toml` (Django/FastAPI/Flask by name), `Gemfile` (→ `rails`), `go.mod` (→ `go-echo`/`go-gin`).
3. AI fallback resolved via `AiProviderManager::resolve()` — no vendor is hard-coded. Prompt asks for a single allowlist slug; output is trimmed, lowercased, and coerced to `other` if it doesn't match the whitelist.

`framework_source` is set to `payload` for steps 1-2, `ai` for step 3, and `manual` for user edits. Detection runs on every sync; because a sync is triggered after initial connect, the first detection happens there.

## Notes & caveats
- Step 3 of the proposed flow (`.github/workflows/*` YAML hints) is intentionally skipped — payload + manifest cover every framework in the allowlist, and AI fallback handles the rest.
- Monorepos record one primary framework (V1 scope per the issue body).
- `pyproject.toml` classification uses simple substring matching; good enough for real-world content and cheap to maintain. Can be tightened to the `[tool.poetry.dependencies]` section if false positives surface.
- Framework allowlist lives as `FrameworkDetector::ALLOWED` and is reused by the UI selector + AI-output coercion.

## Test plan
- [x] Payload-only detection: `composer.json` containing `laravel/framework` → `framework='laravel'`, `framework_source='payload'`.
- [x] Payload-only detection: `package.json` with `next` dep → `framework='nextjs'`, `framework_source='payload'`.
- [x] AI fallback: empty payload + 404 on every manifest → provider returns `nextjs` → `framework='nextjs'`, `framework_source='ai'`.
- [x] AI fallback coercion: provider returns `something-weird` → `framework='other'`.
- [x] Manual override preservation: `framework_source='manual'` causes `detect()` to skip all network calls and keep the stored value.
- [x] Livewire edit flow: `saveFramework` persists the chosen value and flips `framework_source` to `manual`.
- [x] Full suite: 836 tests pass, phpstan clean, pint clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>