### PR TITLE
feat: broadcast sync + intake changes for live Livewire updates (#19)

### DIFF
--- a/app/Events/IntakeQueueChanged.php
+++ b/app/Events/IntakeQueueChanged.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class IntakeQueueChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public int $sourceId,
+        public string $action,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('intake'),
+        ];
+    }
+
+    /**
+     * @return array{source_id: int, action: string}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'source_id' => $this->sourceId,
+            'action' => $this->action,
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'IntakeQueueChanged';
+    }
+}

--- a/app/Events/SourceSynced.php
+++ b/app/Events/SourceSynced.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SourceSynced implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public int $sourceId,
+        public bool $success,
+        public ?string $errorMessage,
+        public ?string $lastSyncedAt,
+    ) {}
+
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel('intake'),
+        ];
+    }
+
+    /**
+     * @return array{source_id: int, success: bool, error_message: ?string, last_synced_at: ?string}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'source_id' => $this->sourceId,
+            'success' => $this->success,
+            'error_message' => $this->errorMessage,
+            'last_synced_at' => $this->lastSyncedAt,
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'SourceSynced';
+    }
+}

--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Enums\IssueStatus;
 use App\Enums\SourceType;
+use App\Events\SourceSynced;
 use App\Models\Repository;
 use App\Models\Source;
 use App\Services\FrameworkDetector;
@@ -76,6 +77,13 @@ class SyncSourceIssuesJob implements ShouldQueue
                 'sync_error' => null,
                 'next_retry_at' => null,
             ]);
+
+            SourceSynced::dispatch(
+                $this->source->id,
+                true,
+                null,
+                now()->toIso8601String(),
+            );
         } catch (\Throwable $e) {
             $this->recordError($e->getMessage());
         }
@@ -205,5 +213,12 @@ class SyncSourceIssuesJob implements ShouldQueue
             'sync_error' => $message,
             'next_retry_at' => now()->addMinutes($this->source->sync_interval ?? 5),
         ]);
+
+        SourceSynced::dispatch(
+            $this->source->id,
+            false,
+            $message,
+            now()->toIso8601String(),
+        );
     }
 }

--- a/app/Services/IssueIntakeService.php
+++ b/app/Services/IssueIntakeService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\IssueStatus;
+use App\Events\IntakeQueueChanged;
 use App\Models\Component;
 use App\Models\Issue;
 use App\Models\Source;
@@ -20,13 +21,23 @@ class IssueIntakeService
             ->first();
 
         if ($existing) {
-            $this->reconcileReopenOnFetchedRow($existing);
-            $this->updateExistingIssue($existing, $issueData);
+            $this->reconcileReopenOnFetchedRow($existing, $source->id);
+            $hadChanges = $this->updateExistingIssue($existing, $issueData);
+
+            if ($hadChanges) {
+                IntakeQueueChanged::dispatch($source->id, 'upsert');
+            }
 
             return $existing->fresh();
         }
 
-        return $this->filterService->applyToSync($issueData, $source);
+        $issue = $this->filterService->applyToSync($issueData, $source);
+
+        if ($issue !== null) {
+            IntakeQueueChanged::dispatch($source->id, 'upsert');
+        }
+
+        return $issue;
     }
 
     public function markClosed(Source $source, string $externalId, ?string $stateReason = null): ?Issue
@@ -51,6 +62,8 @@ class IssueIntakeService
             Issue::where('id', $issue->id)->update(['raw_status' => $rawStatus]);
         }
 
+        IntakeQueueChanged::dispatch($source->id, 'close');
+
         return $issue->fresh();
     }
 
@@ -64,7 +77,7 @@ class IssueIntakeService
             return null;
         }
 
-        $this->reconcileReopenOnFetchedRow($issue);
+        $this->reconcileReopenOnFetchedRow($issue, $source->id);
 
         return $issue->fresh();
     }
@@ -74,9 +87,10 @@ class IssueIntakeService
      * user-driven rejections (distinguished by raw_status being null) and
      * non-Rejected rows. Writes directly using the row we already fetched
      * so callers that pair this with upsert logic don't pay for a second
-     * lookup.
+     * lookup. Broadcasts an `IntakeQueueChanged` `reopen` event when the
+     * row actually transitions.
      */
-    private function reconcileReopenOnFetchedRow(Issue $issue): void
+    private function reconcileReopenOnFetchedRow(Issue $issue, int $sourceId): void
     {
         if ($issue->status !== IssueStatus::Rejected) {
             return;
@@ -96,6 +110,8 @@ class IssueIntakeService
 
         $issue->status = IssueStatus::Queued;
         $issue->raw_status = null;
+
+        IntakeQueueChanged::dispatch($sourceId, 'reopen');
     }
 
     public function markDeleted(Source $source, string $externalId): ?Issue
@@ -115,6 +131,8 @@ class IssueIntakeService
         if ($rejected === 0) {
             Issue::where('id', $issue->id)->update(['raw_status' => 'deleted']);
         }
+
+        IntakeQueueChanged::dispatch($source->id, 'delete');
 
         return $issue->fresh();
     }
@@ -140,7 +158,7 @@ class IssueIntakeService
         return $component->id;
     }
 
-    private function updateExistingIssue(Issue $issue, array $issueData): void
+    private function updateExistingIssue(Issue $issue, array $issueData): bool
     {
         $updatable = ['title', 'body', 'external_url', 'assignee', 'labels', 'raw_status'];
         $changes = [];
@@ -161,6 +179,10 @@ class IssueIntakeService
 
         if (! empty($changes)) {
             $issue->update($changes);
+
+            return true;
         }
+
+        return false;
     }
 }

--- a/resources/views/pages/⚡intake.blade.php
+++ b/resources/views/pages/⚡intake.blade.php
@@ -13,6 +13,7 @@ use App\Services\JiraClient;
 use App\Services\OauthService;
 use App\Services\OrchestratorService;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 
@@ -23,6 +24,18 @@ class extends Component
 {
     /** source id → flash message for the last test-connection call */
     public array $testResults = [];
+
+    #[On('echo-private:intake,.IntakeQueueChanged')]
+    public function handleIntakeQueueChanged(): void
+    {
+        // Re-render handled automatically by Livewire when this method is called.
+    }
+
+    #[On('echo-private:intake,.SourceSynced')]
+    public function handleSourceSynced(): void
+    {
+        // Re-render handled automatically by Livewire when this method is called.
+    }
 
     /** source id → flash message for the last sync-now call */
     public array $syncResults = [];

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+Broadcast::channel('intake', function ($user) {
+    return auth()->check();
+});

--- a/tests/Feature/IntakeBroadcastTest.php
+++ b/tests/Feature/IntakeBroadcastTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\IssueStatus;
+use App\Enums\SourceType;
+use App\Events\IntakeQueueChanged;
+use App\Events\SourceSynced;
+use App\Jobs\SyncSourceIssuesJob;
+use App\Models\Issue;
+use App\Models\OauthToken;
+use App\Models\Source;
+use App\Services\IssueIntakeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class IntakeBroadcastTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createGitHubSource(): Source
+    {
+        return Source::factory()->create([
+            'type' => SourceType::GitHub,
+            'external_account' => 'testuser',
+            'is_active' => true,
+            'config' => ['repositories' => ['owner/repo']],
+        ]);
+    }
+
+    private function createToken(Source $source): void
+    {
+        OauthToken::factory()->create([
+            'source_id' => $source->id,
+            'provider' => $source->type->value,
+            'access_token' => 'test-token',
+            'expires_at' => now()->addHour(),
+        ]);
+    }
+
+    public function test_sync_job_broadcasts_source_synced_on_success(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo/issues*' => Http::response([]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        Event::assertDispatched(SourceSynced::class, function (SourceSynced $event) use ($source) {
+            return $event->sourceId === $source->id
+                && $event->success === true
+                && $event->errorMessage === null;
+        });
+    }
+
+    public function test_sync_job_broadcasts_source_synced_on_error(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+        // No token — triggers recordError path.
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        Event::assertDispatched(SourceSynced::class, function (SourceSynced $event) use ($source) {
+            return $event->sourceId === $source->id
+                && $event->success === false
+                && $event->errorMessage !== null;
+        });
+    }
+
+    public function test_sync_job_broadcasts_source_synced_on_api_failure(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/*' => Http::response('Server error', 500),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        Event::assertDispatched(SourceSynced::class, function (SourceSynced $event) use ($source) {
+            return $event->sourceId === $source->id
+                && $event->success === false
+                && $event->errorMessage !== null;
+        });
+    }
+
+    public function test_upsert_issue_broadcasts_intake_queue_changed_for_new_issue(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->upsertIssue($source, [
+            'external_id' => 'owner/repo#42',
+            'title' => 'New issue',
+            'body' => 'Body text',
+            'external_url' => 'https://github.com/owner/repo/issues/42',
+            'assignee' => null,
+            'labels' => [],
+        ]);
+
+        Event::assertDispatched(IntakeQueueChanged::class, function (IntakeQueueChanged $event) use ($source) {
+            return $event->sourceId === $source->id && $event->action === 'upsert';
+        });
+    }
+
+    public function test_upsert_issue_broadcasts_intake_queue_changed_when_existing_issue_changes(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Old title',
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->upsertIssue($source, [
+            'external_id' => 'owner/repo#1',
+            'title' => 'Updated title',
+            'body' => null,
+            'external_url' => null,
+            'assignee' => null,
+            'labels' => [],
+        ]);
+
+        Event::assertDispatched(IntakeQueueChanged::class, function (IntakeQueueChanged $event) use ($source) {
+            return $event->sourceId === $source->id && $event->action === 'upsert';
+        });
+    }
+
+    public function test_upsert_issue_does_not_broadcast_when_no_changes(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Same title',
+            'body' => null,
+            'external_url' => null,
+            'assignee' => null,
+            'labels' => [],
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->upsertIssue($source, [
+            'external_id' => 'owner/repo#1',
+            'title' => 'Same title',
+            'body' => null,
+            'external_url' => null,
+            'assignee' => null,
+            'labels' => [],
+        ]);
+
+        Event::assertNotDispatched(IntakeQueueChanged::class);
+    }
+
+    public function test_mark_closed_broadcasts_intake_queue_changed(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Open issue',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markClosed($source, 'owner/repo#1');
+
+        Event::assertDispatched(IntakeQueueChanged::class, function (IntakeQueueChanged $event) use ($source) {
+            return $event->sourceId === $source->id && $event->action === 'close';
+        });
+    }
+
+    public function test_mark_closed_does_not_broadcast_when_issue_not_found(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markClosed($source, 'owner/repo#999');
+
+        Event::assertNotDispatched(IntakeQueueChanged::class);
+    }
+
+    public function test_mark_reopened_broadcasts_intake_queue_changed(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Closed issue',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => 'closed:completed',
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markReopened($source, 'owner/repo#1');
+
+        Event::assertDispatched(IntakeQueueChanged::class, function (IntakeQueueChanged $event) use ($source) {
+            return $event->sourceId === $source->id && $event->action === 'reopen';
+        });
+    }
+
+    public function test_mark_reopened_does_not_broadcast_when_no_state_change(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        // Rejected due to local action, not a sync-driven close — should not reopen.
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Manually rejected',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => null,
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markReopened($source, 'owner/repo#1');
+
+        Event::assertNotDispatched(IntakeQueueChanged::class);
+    }
+
+    public function test_mark_deleted_broadcasts_intake_queue_changed(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        Issue::factory()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#1',
+            'title' => 'Existing issue',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markDeleted($source, 'owner/repo#1');
+
+        Event::assertDispatched(IntakeQueueChanged::class, function (IntakeQueueChanged $event) use ($source) {
+            return $event->sourceId === $source->id && $event->action === 'delete';
+        });
+    }
+
+    public function test_mark_deleted_does_not_broadcast_when_issue_not_found(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+
+        /** @var IssueIntakeService $service */
+        $service = app(IssueIntakeService::class);
+        $service->markDeleted($source, 'owner/repo#999');
+
+        Event::assertNotDispatched(IntakeQueueChanged::class);
+    }
+
+    public function test_sync_job_broadcasts_intake_queue_changed_for_each_new_issue(): void
+    {
+        Event::fake([SourceSynced::class, IntakeQueueChanged::class]);
+
+        $source = $this->createGitHubSource();
+        $this->createToken($source);
+
+        Http::fake([
+            'api.github.com/repos/owner/repo/issues*' => Http::response([
+                [
+                    'number' => 1,
+                    'title' => 'First issue',
+                    'body' => '',
+                    'html_url' => 'https://github.com/owner/repo/issues/1',
+                    'assignee' => null,
+                    'labels' => [],
+                ],
+                [
+                    'number' => 2,
+                    'title' => 'Second issue',
+                    'body' => '',
+                    'html_url' => 'https://github.com/owner/repo/issues/2',
+                    'assignee' => null,
+                    'labels' => [],
+                ],
+            ]),
+        ]);
+
+        SyncSourceIssuesJob::dispatchSync($source);
+
+        Event::assertDispatchedTimes(IntakeQueueChanged::class, 2);
+        Event::assertDispatched(SourceSynced::class, function (SourceSynced $event) use ($source) {
+            return $event->sourceId === $source->id && $event->success === true;
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SourceSynced` and `IntakeQueueChanged` broadcast events on the private `intake` channel
- `SyncSourceIssuesJob` dispatches `SourceSynced` on both success and failure paths
- `IssueIntakeService` dispatches `IntakeQueueChanged` (with action: `upsert`, `close`, `reopen`, `delete`) at each boundary method, only when state actually changes
- `routes/channels.php` adds `Broadcast::channel('intake', ...)` auth (requires authenticated user)
- Livewire intake component gains `#[On('echo-private:intake,.IntakeQueueChanged')]` and `#[On('echo-private:intake,.SourceSynced')]` listeners that trigger a re-render
- Echo/Reverb client already wired in `resources/js/bootstrap.js` + `echo.js` — no JS changes needed

## Test plan

- [x] `IntakeBroadcastTest` (13 new tests): `Event::fake()` assertions for `SourceSynced` on sync success/failure and `IntakeQueueChanged` on upsert/close/reopen/delete, including no-op guard checks
- [x] Full test suite: 843 tests, all passing
- [x] Pint: no formatting issues
- [x] PHPStan level 5: no errors
- [ ] Browser verification: not verified in browser (no dev server available) — `Event::fake()` tests are the contract

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)