### PR TITLE
feat: archive/unarchive issues as local hide toggle (#22)

### DIFF
--- a/app/Jobs/SyncSourceIssuesJob.php
+++ b/app/Jobs/SyncSourceIssuesJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Enums\IssueStatus;
 use App\Enums\SourceType;
 use App\Events\SourceSynced;
+use App\Models\Issue;
 use App\Models\Repository;
 use App\Models\Source;
 use App\Services\FrameworkDetector;
@@ -194,7 +195,8 @@ class SyncSourceIssuesJob implements ShouldQueue
         }
 
         if ($this->source->backlog_threshold) {
-            $queuedCount = $this->source->issues()
+            $queuedCount = Issue::where('source_id', $this->source->id)
+                ->active()
                 ->where('status', IssueStatus::Queued)
                 ->count();
 

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 use App\Enums\IssueStatus;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 
 /**
  * @property IssueStatus $status
@@ -14,6 +16,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property bool $auto_accepted
  * @property int|null $component_id
  * @property int|null $repository_id
+ * @property Carbon|null $archived_at
+ * @property string|null $archived_reason
  * @property-read Component|null $component
  * @property-read Repository|null $repository
  * @property-read Source $source
@@ -35,6 +39,8 @@ class Issue extends Model
         'assignee',
         'labels',
         'auto_accepted',
+        'archived_at',
+        'archived_reason',
     ];
 
     protected function casts(): array
@@ -43,7 +49,46 @@ class Issue extends Model
             'status' => IssueStatus::class,
             'labels' => 'array',
             'auto_accepted' => 'boolean',
+            'archived_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Scope to issues that have not been archived.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->whereNull('archived_at');
+    }
+
+    /**
+     * Scope to issues that have been archived.
+     */
+    public function scopeArchived(Builder $query): Builder
+    {
+        return $query->whereNotNull('archived_at');
+    }
+
+    /**
+     * Archive this issue with an optional user-provided reason.
+     */
+    public function archive(?string $reason = null): void
+    {
+        $this->update([
+            'archived_at' => now(),
+            'archived_reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Unarchive this issue, clearing archived_at and archived_reason.
+     */
+    public function unarchive(): void
+    {
+        $this->update([
+            'archived_at' => null,
+            'archived_reason' => null,
+        ]);
     }
 
     public function source(): BelongsTo

--- a/app/Services/IssueIntakeService.php
+++ b/app/Services/IssueIntakeService.php
@@ -21,6 +21,10 @@ class IssueIntakeService
             ->first();
 
         if ($existing) {
+            if ($existing->archived_at !== null) {
+                $existing->unarchive();
+            }
+
             $this->reconcileReopenOnFetchedRow($existing, $source->id);
             $hadChanges = $this->updateExistingIssue($existing, $issueData);
 
@@ -50,6 +54,10 @@ class IssueIntakeService
             return null;
         }
 
+        if ($issue->archived_at !== null) {
+            $issue->unarchive();
+        }
+
         $rawStatus = $stateReason !== null ? 'closed:'.$stateReason : 'closed';
 
         $transitioned = Issue::where('id', $issue->id)
@@ -75,6 +83,10 @@ class IssueIntakeService
 
         if (! $issue) {
             return null;
+        }
+
+        if ($issue->archived_at !== null) {
+            $issue->unarchive();
         }
 
         $this->reconcileReopenOnFetchedRow($issue, $source->id);
@@ -122,6 +134,10 @@ class IssueIntakeService
 
         if (! $issue) {
             return null;
+        }
+
+        if ($issue->archived_at !== null) {
+            $issue->unarchive();
         }
 
         $rejected = Issue::where('id', $issue->id)

--- a/database/factories/IssueFactory.php
+++ b/database/factories/IssueFactory.php
@@ -8,6 +8,9 @@ use App\Models\Repository;
 use App\Models\Source;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Issue>
+ */
 class IssueFactory extends Factory
 {
     protected $model = Issue::class;
@@ -25,6 +28,19 @@ class IssueFactory extends Factory
             'assignee' => fake()->optional()->userName(),
             'labels' => fake()->optional()->randomElements(['bug', 'feature', 'enhancement', 'docs'], 2),
             'auto_accepted' => false,
+            'archived_at' => null,
+            'archived_reason' => null,
         ];
+    }
+
+    /**
+     * Mark the issue as archived with an optional reason.
+     */
+    public function archived(?string $reason = null): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'archived_at' => now(),
+            'archived_reason' => $reason,
+        ]);
     }
 }

--- a/database/migrations/2026_04_18_150947_add_archive_columns_to_issues_table.php
+++ b/database/migrations/2026_04_18_150947_add_archive_columns_to_issues_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->timestamp('archived_at')->nullable()->after('auto_accepted');
+            $table->string('archived_reason')->nullable()->after('archived_at');
+
+            $table->index(['source_id', 'archived_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->dropIndex(['source_id', 'archived_at']);
+            $table->dropColumn(['archived_at', 'archived_reason']);
+        });
+    }
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,12 +265,6 @@ parameters:
 			path: database/seeders/DemoDataSeeder.php
 
 		-
-			message: '#^Parameter \#1 \$issue of method Database\\Seeders\\DemoDataSeeder\:\:buildPipelineFor\(\) expects App\\Models\\Issue, Illuminate\\Database\\Eloquent\\Model given\.$#'
-			identifier: argument.type
-			count: 1
-			path: database/seeders/DemoDataSeeder.php
-
-		-
 			message: '#^Parameter \#1 \$run of method Database\\Seeders\\DemoDataSeeder\:\:stagesCompleted\(\) expects App\\Models\\Run, Illuminate\\Database\\Eloquent\\Model given\.$#'
 			identifier: argument.type
 			count: 1
@@ -345,7 +339,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 22
+			count: 19
 			path: tests/Feature/ActivityFeedTest.php
 
 		-
@@ -353,12 +347,6 @@ parameters:
 			identifier: method.alreadyNarrowedType
 			count: 1
 			path: tests/Feature/AiProviderTest.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 28
-			path: tests/Feature/AutonomyResolverTest.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$condition\.$#'
@@ -375,7 +363,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 8
+			count: 6
 			path: tests/Feature/CoreSchemaTest.php
 
 		-
@@ -397,12 +385,6 @@ parameters:
 			path: tests/Feature/CoreSchemaTest.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$runs\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Feature/CoreSchemaTest.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$scope\.$#'
 			identifier: property.notFound
 			count: 1
@@ -417,13 +399,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$source\.$#'
 			identifier: property.notFound
-			count: 3
-			path: tests/Feature/CoreSchemaTest.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$source_id\.$#'
-			identifier: property.notFound
-			count: 1
+			count: 2
 			path: tests/Feature/CoreSchemaTest.php
 
 		-
@@ -441,7 +417,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$status\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/CoreSchemaTest.php
 
 		-
@@ -465,7 +441,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 13
+			count: 10
 			path: tests/Feature/EscalationRuleEngineTest.php
 
 		-
@@ -493,18 +469,6 @@ parameters:
 			path: tests/Feature/EscalationRuleEngineTest.php
 
 		-
-			message: '#^Parameter \#1 \$issue of method App\\Services\\EscalationRuleService\:\:evaluateRules\(\) expects App\\Models\\Issue, Illuminate\\Database\\Eloquent\\Model given\.$#'
-			identifier: argument.type
-			count: 18
-			path: tests/Feature/EscalationRuleEngineTest.php
-
-		-
-			message: '#^Parameter \#1 \$issue of method App\\Services\\EscalationRuleService\:\:resolveWithEscalation\(\) expects App\\Models\\Issue, Illuminate\\Database\\Eloquent\\Model given\.$#'
-			identifier: argument.type
-			count: 10
-			path: tests/Feature/EscalationRuleEngineTest.php
-
-		-
 			message: '#^Parameter \#4 \$stageModel of method App\\Services\\EscalationRuleService\:\:resolveWithEscalation\(\) expects App\\Models\\Stage\|null, Illuminate\\Database\\Eloquent\\Model given\.$#'
 			identifier: argument.type
 			count: 3
@@ -513,7 +477,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/ExecuteStageJobTest.php
 
 		-
@@ -543,7 +507,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/ImplementAgentTest.php
 
 		-
@@ -565,12 +529,6 @@ parameters:
 			path: tests/Feature/ImplementAgentTest.php
 
 		-
-			message: '#^Method Tests\\Feature\\IssueQueueTest\:\:createIssue\(\) should return App\\Models\\Issue but returns Illuminate\\Database\\Eloquent\\Model\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/Feature/IssueQueueTest.php
-
-		-
 			message: '#^Cannot call method isFuture\(\) on string\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -589,22 +547,10 @@ parameters:
 			path: tests/Feature/IssueViewTest.php
 
 		-
-			message: '#^Method Tests\\Feature\\IssueViewTest\:\:createPipelineIssue\(\) should return App\\Models\\Issue but returns Illuminate\\Database\\Eloquent\\Model\.$#'
-			identifier: return.type
-			count: 1
-			path: tests/Feature/IssueViewTest.php
-
-		-
 			message: '#^Property Tests\\Feature\\JiraClientTest\:\:\$token \(App\\Models\\OauthToken\) does not accept Illuminate\\Database\\Eloquent\\Model\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/Feature/JiraClientTest.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Feature/MergeConflictDetectorTest.php
 
 		-
 			message: '#^Property Tests\\Feature\\MergeConflictDetectorTest\:\:\$repository \(App\\Models\\Repository\) does not accept Illuminate\\Database\\Eloquent\\Model\.$#'
@@ -623,12 +569,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: tests/Feature/MergeConflictDetectorTest.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: tests/Feature/MobileBuildTest.php
 
 		-
 			message: '#^Parameter \#1 \$run of class App\\Events\\RunStuck constructor expects App\\Models\\Run, Illuminate\\Database\\Eloquent\\Model given\.$#'
@@ -717,7 +657,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 41
+			count: 40
 			path: tests/Feature/OrchestratorServiceTest.php
 
 		-
@@ -745,12 +685,6 @@ parameters:
 			path: tests/Feature/OrchestratorServiceTest.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$repository_id\.$#'
-			identifier: property.notFound
-			count: 2
-			path: tests/Feature/OrchestratorServiceTest.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$run_id\.$#'
 			identifier: property.notFound
 			count: 1
@@ -765,7 +699,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$status\.$#'
 			identifier: property.notFound
-			count: 26
+			count: 24
 			path: tests/Feature/OrchestratorServiceTest.php
 
 		-
@@ -784,12 +718,6 @@ parameters:
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:stages\(\)\.$#'
 			identifier: method.notFound
 			count: 11
-			path: tests/Feature/OrchestratorServiceTest.php
-
-		-
-			message: '#^Parameter \#1 \$issue of method App\\Services\\OrchestratorService\:\:startRun\(\) expects App\\Models\\Issue, Illuminate\\Database\\Eloquent\\Model given\.$#'
-			identifier: argument.type
-			count: 17
 			path: tests/Feature/OrchestratorServiceTest.php
 
 		-
@@ -873,7 +801,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/OverviewTest.php
 
 		-
@@ -883,21 +811,9 @@ parameters:
 			path: tests/Feature/OverviewTest.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Feature/PipelineObservabilityTest.php
-
-		-
 			message: '#^Generator expects value type array\{type\: string, content\: string\|null, tool_calls\: array\|null, usage\: array\|null\}, array\{\} given\.$#'
 			identifier: generator.valueType
 			count: 1
-			path: tests/Feature/PipelineObservabilityTest.php
-
-		-
-			message: '#^Parameter \#1 \$issue of method App\\Services\\OrchestratorService\:\:startRun\(\) expects App\\Models\\Issue, Illuminate\\Database\\Eloquent\\Model given\.$#'
-			identifier: argument.type
-			count: 3
 			path: tests/Feature/PipelineObservabilityTest.php
 
 		-
@@ -927,7 +843,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/PreflightAgentTest.php
 
 		-
@@ -951,7 +867,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/PreflightDocTest.php
 
 		-
@@ -1005,7 +921,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 2
 			path: tests/Feature/ReleaseAgentTest.php
 
 		-
@@ -1017,7 +933,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 2
 			path: tests/Feature/ResolveConflictsJobTest.php
 
 		-
@@ -1029,7 +945,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 16
+			count: 10
 			path: tests/Feature/RunProgressTest.php
 
 		-
@@ -1047,7 +963,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 1
 			path: tests/Feature/VerifyAgentTest.php
 
 		-
@@ -1055,12 +971,6 @@ parameters:
 			identifier: generator.valueType
 			count: 2
 			path: tests/Feature/VerifyAgentTest.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: tests/Feature/WorktreeServiceTest.php
 
 		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:events\(\)\.$#'

--- a/resources/views/pages/⚡intake.blade.php
+++ b/resources/views/pages/⚡intake.blade.php
@@ -2,6 +2,7 @@
 
 use App\Enums\FrameworkSource;
 use App\Enums\IssueStatus;
+use App\Enums\RunStatus;
 use App\Jobs\SyncSourceIssuesJob;
 use App\Models\Issue;
 use App\Models\OauthToken;
@@ -42,6 +43,9 @@ class extends Component
 
     /** "sourceId-repoFullName" → currently-editing flag */
     public array $editingFramework = [];
+
+    /** Whether to show archived issues in the queue. */
+    public bool $showArchived = false;
 
     public function startEditFramework(int $sourceId, string $repoFullName): void
     {
@@ -147,6 +151,27 @@ class extends Component
         }
     }
 
+    public function archiveIssue(int $issueId, string $reason = ''): void
+    {
+        $issue = Issue::findOrFail($issueId);
+
+        if ($issue->runs()->whereIn('status', [RunStatus::Pending, RunStatus::Running, RunStatus::Stuck])->exists()) {
+            session()->flash('error', 'Cancel the in-flight run before archiving this issue.');
+
+            return;
+        }
+
+        $issue->archive($reason !== '' ? $reason : null);
+        session()->flash('success', "Issue \"{$issue->title}\" archived.");
+    }
+
+    public function unarchiveIssue(int $issueId): void
+    {
+        $issue = Issue::findOrFail($issueId);
+        $issue->unarchive();
+        session()->flash('success', "Issue \"{$issue->title}\" unarchived.");
+    }
+
     public function acceptIssue(int $issueId, OrchestratorService $orchestrator, ?int $repositoryId = null): void
     {
         $issue = Issue::findOrFail($issueId);
@@ -210,18 +235,24 @@ class extends Component
 
         $repositoriesByName = Repository::whereIn('name', $repoNames)->get()->keyBy('name');
 
+        $incomingQuery = Issue::with(['source', 'component.repositories', 'repository'])
+            ->orderByDesc('created_at')
+            ->limit(15);
+
+        if ($this->showArchived) {
+            $incomingQuery->archived();
+        } else {
+            $incomingQuery->active()->where('status', IssueStatus::Queued);
+        }
+
         return [
             'sources' => $sources,
             'pausedCount' => $sources->where('is_intake_paused', true)->count(),
             'connectedCount' => $sources->where('is_active', true)->count(),
             'repositoriesByName' => $repositoriesByName,
             'frameworkOptions' => FrameworkDetector::ALLOWED,
-            'incoming' => Issue::with(['source', 'component.repositories', 'repository'])
-                ->where('status', IssueStatus::Queued)
-                ->orderByDesc('created_at')
-                ->limit(15)
-                ->get(),
-            'pendingCount' => Issue::where('status', IssueStatus::Queued)->count(),
+            'incoming' => $incomingQuery->get(),
+            'pendingCount' => Issue::active()->where('status', IssueStatus::Queued)->count(),
         ];
     }
 };
@@ -774,17 +805,29 @@ class extends Component
     <section class="space-y-3">
         <div class="flex items-center justify-between px-1">
             <h2 class="font-headline text-xl text-on-surface">Incoming Queue</h2>
-            <span class="font-label text-[10px] text-outline uppercase tracking-widest">
-                Pending {{ str_pad((string) $pendingCount, 2, '0', STR_PAD_LEFT) }}
-            </span>
+            <div class="flex items-center gap-3">
+                <button type="button" wire:click="$toggle('showArchived')"
+                        class="font-label text-[10px] uppercase tracking-widest {{ $showArchived ? 'text-stage-stuck' : 'text-outline' }} hover:underline">
+                    {{ $showArchived ? 'Hide Archived' : 'Show Archived' }}
+                </button>
+                @if (! $showArchived)
+                    <span class="font-label text-[10px] text-outline uppercase tracking-widest">
+                        Pending {{ str_pad((string) $pendingCount, 2, '0', STR_PAD_LEFT) }}
+                    </span>
+                @endif
+            </div>
         </div>
 
         @if ($incoming->isEmpty())
             <div class="bg-surface-container-low rounded-xl p-8 text-center">
-                <p class="text-on-surface-variant">No incoming issues.</p>
-                <p class="font-label text-[10px] text-outline uppercase tracking-widest mt-1">
-                    Next sync will pull any new items
-                </p>
+                @if ($showArchived)
+                    <p class="text-on-surface-variant">No archived issues.</p>
+                @else
+                    <p class="text-on-surface-variant">No incoming issues.</p>
+                    <p class="font-label text-[10px] text-outline uppercase tracking-widest mt-1">
+                        Next sync will pull any new items
+                    </p>
+                @endif
             </div>
         @else
             @foreach ($incoming as $issue)
@@ -803,6 +846,10 @@ class extends Component
                                 </span>
                                 <span class="text-outline-variant">·</span>
                                 <span class="text-primary">{{ $externalRef }}</span>
+                                @if ($issue->archived_at)
+                                    <span class="text-outline-variant">·</span>
+                                    <span class="inline-flex items-center rounded bg-stage-stuck/20 text-stage-stuck px-1.5 py-0.5 tracking-wider">Archived {{ $issue->archived_at->diffForHumans(null, true) }} ago</span>
+                                @endif
                                 @if ($issue->raw_status)
                                     <span class="text-outline-variant">·</span>
                                     <span class="inline-flex items-center rounded bg-secondary-container text-on-secondary-container px-1.5 py-0.5 tracking-wider">{{ $issue->raw_status }}</span>
@@ -816,6 +863,10 @@ class extends Component
                             </div>
 
                             <h3 class="text-sm font-semibold text-on-surface leading-snug">{{ $issue->title }}</h3>
+
+                            @if ($issue->archived_reason)
+                                <p class="text-xs text-stage-stuck italic">Reason: {{ $issue->archived_reason }}</p>
+                            @endif
 
                             @if ($issue->body)
                                 <div>
@@ -838,45 +889,59 @@ class extends Component
                         </div>
 
                         <div class="shrink-0 flex flex-col gap-1 min-w-[9rem]">
-                            @php
-                                $componentRepos = $issue->component?->repositories ?? collect();
-                                $hasDirectRepo = (bool) $issue->repository_id;
-                            @endphp
-
-                            @if ($hasDirectRepo)
-                                <button type="button" wire:click="acceptIssue({{ $issue->id }})"
+                            @if ($showArchived)
+                                <button type="button" wire:click="unarchiveIssue({{ $issue->id }})"
                                         class="w-full rounded-md bg-primary text-on-primary px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-primary/90">
-                                    Accept
+                                    Unarchive
                                 </button>
-                            @elseif ($issue->component_id && $componentRepos->isNotEmpty())
-                                <span class="font-label text-[10px] text-outline uppercase tracking-wider text-right">
-                                    Start on · {{ $issue->component->name }}
-                                </span>
-                                @foreach ($componentRepos as $repo)
-                                    <button type="button" wire:click="acceptIssue({{ $issue->id }}, {{ $repo->id }})"
-                                            class="w-full rounded-md bg-primary text-on-primary px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-primary/90 font-mono truncate"
-                                            title="{{ $repo->name }}">
-                                        {{ $repo->name }}
-                                    </button>
-                                @endforeach
-                            @elseif ($issue->component_id)
-                                <span class="rounded-md bg-stage-stuck/20 text-stage-stuck px-3 py-1.5 font-label text-[10px] uppercase tracking-widest text-center">
-                                    No repos for {{ $issue->component->name }}
-                                </span>
-                                <a href="{{ route('components.index', $issue->source) }}"
-                                   class="w-full rounded-md bg-surface-container-high text-on-surface px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest text-center">
-                                    Map repos →
-                                </a>
                             @else
-                                <span class="rounded-md bg-stage-stuck/20 text-stage-stuck px-3 py-1.5 font-label text-[10px] uppercase tracking-widest text-center">
-                                    No component
-                                </span>
-                            @endif
+                                @php
+                                    $componentRepos = $issue->component?->repositories ?? collect();
+                                    $hasDirectRepo = (bool) $issue->repository_id;
+                                @endphp
 
-                            <button type="button" wire:click="rejectIssue({{ $issue->id }})"
-                                    class="w-full rounded-md bg-surface-container-high text-on-surface px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest">
-                                Reject
-                            </button>
+                                @if ($hasDirectRepo)
+                                    <button type="button" wire:click="acceptIssue({{ $issue->id }})"
+                                            class="w-full rounded-md bg-primary text-on-primary px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-primary/90">
+                                        Accept
+                                    </button>
+                                @elseif ($issue->component_id && $componentRepos->isNotEmpty())
+                                    <span class="font-label text-[10px] text-outline uppercase tracking-wider text-right">
+                                        Start on · {{ $issue->component->name }}
+                                    </span>
+                                    @foreach ($componentRepos as $repo)
+                                        <button type="button" wire:click="acceptIssue({{ $issue->id }}, {{ $repo->id }})"
+                                                class="w-full rounded-md bg-primary text-on-primary px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-primary/90 font-mono truncate"
+                                                title="{{ $repo->name }}">
+                                            {{ $repo->name }}
+                                        </button>
+                                    @endforeach
+                                @elseif ($issue->component_id)
+                                    <span class="rounded-md bg-stage-stuck/20 text-stage-stuck px-3 py-1.5 font-label text-[10px] uppercase tracking-widest text-center">
+                                        No repos for {{ $issue->component->name }}
+                                    </span>
+                                    <a href="{{ route('components.index', $issue->source) }}"
+                                       class="w-full rounded-md bg-surface-container-high text-on-surface px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest text-center">
+                                        Map repos →
+                                    </a>
+                                @else
+                                    <span class="rounded-md bg-stage-stuck/20 text-stage-stuck px-3 py-1.5 font-label text-[10px] uppercase tracking-widest text-center">
+                                        No component
+                                    </span>
+                                @endif
+
+                                <button type="button"
+                                        x-data
+                                        x-on:click="$wire.archiveIssue({{ $issue->id }}, prompt('Archive reason (optional):') ?? '')"
+                                        class="w-full rounded-md bg-surface-container-high text-on-surface px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest">
+                                    Archive
+                                </button>
+
+                                <button type="button" wire:click="rejectIssue({{ $issue->id }})"
+                                        class="w-full rounded-md bg-surface-container-high text-on-surface px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest">
+                                    Reject
+                                </button>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/pages/⚡issue.blade.php
+++ b/resources/views/pages/⚡issue.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\IssueStatus;
+use App\Enums\RunStatus;
 use App\Models\Issue;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
@@ -16,12 +17,25 @@ class extends Component
         return $this->issue->title ?: 'Issues';
     }
 
+    public function archiveIssue(string $reason = ''): void
+    {
+        if ($this->issue->runs()->whereIn('status', [RunStatus::Pending, RunStatus::Running, RunStatus::Stuck])->exists()) {
+            session()->flash('error', 'Cancel the in-flight run before archiving this issue.');
+
+            return;
+        }
+
+        $this->issue->archive($reason !== '' ? $reason : null);
+        $this->redirect(route('intake.index'), navigate: true);
+    }
+
     public function with(): array
     {
         $issues = Issue::with([
             'runs' => fn ($q) => $q->latest('id')->limit(1),
             'runs.stages' => fn ($q) => $q->latest('id')->limit(1),
         ])
+            ->active()
             ->whereIn('status', [
                 IssueStatus::Accepted,
                 IssueStatus::InProgress,
@@ -525,6 +539,15 @@ class extends Component
                                 <span><kbd class="px-1 py-0.5 bg-surface-container-high rounded text-xs">J</kbd> Next</span>
                                 <span><kbd class="px-1 py-0.5 bg-surface-container-high rounded text-xs">K</kbd> Previous</span>
                             </div>
+                        </div>
+
+                        <div class="mt-4 pt-4 border-t border-outline-variant/40">
+                            <button type="button"
+                                    x-data
+                                    x-on:click="$wire.archiveIssue(prompt('Archive reason (optional):') ?? '')"
+                                    class="w-full rounded-md bg-surface-container-high text-on-surface-variant px-3 py-1.5 font-label text-[10px] uppercase tracking-widest hover:bg-surface-container-highest text-center">
+                                Archive Issue
+                            </button>
                         </div>
                     </div>
                 @endif

--- a/tests/Feature/IssueArchiveTest.php
+++ b/tests/Feature/IssueArchiveTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\IssueStatus;
+use App\Enums\RunStatus;
+use App\Enums\SourceType;
+use App\Models\Issue;
+use App\Models\Run;
+use App\Models\Source;
+use App\Services\IssueIntakeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class IssueArchiveTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createSource(array $overrides = []): Source
+    {
+        return Source::factory()->create(array_merge([
+            'type' => SourceType::GitHub,
+            'is_active' => true,
+            'external_account' => 'testuser',
+        ], $overrides));
+    }
+
+    private function createIssue(Source $source, array $overrides = []): Issue
+    {
+        return Issue::factory()->create(array_merge([
+            'source_id' => $source->id,
+            'status' => IssueStatus::Queued,
+        ], $overrides));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Model scope + helper tests
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_scope_active_excludes_archived_issues(): void
+    {
+        $source = $this->createSource();
+        $active = $this->createIssue($source, ['title' => 'Active issue']);
+        $archived = $this->createIssue($source, ['title' => 'Archived issue']);
+        $archived->archive();
+
+        $results = Issue::active()->get();
+
+        $this->assertTrue($results->contains($active));
+        $this->assertFalse($results->contains($archived));
+    }
+
+    public function test_scope_archived_returns_only_archived_issues(): void
+    {
+        $source = $this->createSource();
+        $active = $this->createIssue($source, ['title' => 'Active issue']);
+        $archived = $this->createIssue($source, ['title' => 'Archived issue']);
+        $archived->archive();
+
+        $results = Issue::archived()->get();
+
+        $this->assertFalse($results->contains($active));
+        $this->assertTrue($results->contains($archived));
+    }
+
+    public function test_archive_helper_sets_archived_at_and_reason(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source);
+
+        $issue->archive('Too old to matter');
+
+        $issue->refresh();
+        $this->assertNotNull($issue->archived_at);
+        $this->assertEquals('Too old to matter', $issue->archived_reason);
+    }
+
+    public function test_archive_helper_without_reason(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source);
+
+        $issue->archive();
+
+        $issue->refresh();
+        $this->assertNotNull($issue->archived_at);
+        $this->assertNull($issue->archived_reason);
+    }
+
+    public function test_unarchive_helper_clears_archive_fields(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source);
+        $issue->archive('Some reason');
+
+        $issue->unarchive();
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertNull($issue->archived_reason);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Factory state tests
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_factory_archived_state(): void
+    {
+        $source = $this->createSource();
+        $issue = Issue::factory()->archived('factory reason')->create(['source_id' => $source->id]);
+
+        $this->assertNotNull($issue->archived_at);
+        $this->assertEquals('factory reason', $issue->archived_reason);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Intake queue: active() scope applied by default
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_intake_queue_does_not_show_archived_issues(): void
+    {
+        $source = $this->createSource();
+        $this->createIssue($source, ['title' => 'Visible issue']);
+        $archived = $this->createIssue($source, ['title' => 'Archived issue']);
+        $archived->archive();
+
+        $response = $this->get('/intake');
+
+        $response->assertSee('Visible issue');
+        $response->assertDontSee('Archived issue');
+    }
+
+    public function test_pending_count_excludes_archived_issues(): void
+    {
+        $source = $this->createSource();
+        $this->createIssue($source);
+        $archived = $this->createIssue($source);
+        $archived->archive();
+
+        Livewire::test('pages::intake')
+            ->assertSee('Pending 01');
+    }
+
+    public function test_show_archived_toggle_reveals_archived_issues(): void
+    {
+        $source = $this->createSource();
+        $this->createIssue($source, ['title' => 'Active issue']);
+        $archived = $this->createIssue($source, ['title' => 'My archived issue']);
+        $archived->archive('Test reason');
+
+        Livewire::test('pages::intake')
+            ->assertDontSee('My archived issue')
+            ->set('showArchived', true)
+            ->assertSee('My archived issue')
+            ->assertSee('Test reason');
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Archive action (Livewire)
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_archive_issue_via_livewire(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source, ['title' => 'Archive me']);
+
+        Livewire::test('pages::intake')
+            ->call('archiveIssue', $issue->id, 'no longer relevant');
+
+        $issue->refresh();
+        $this->assertNotNull($issue->archived_at);
+        $this->assertEquals('no longer relevant', $issue->archived_reason);
+    }
+
+    public function test_archive_issue_without_reason(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source);
+
+        Livewire::test('pages::intake')
+            ->call('archiveIssue', $issue->id, '');
+
+        $issue->refresh();
+        $this->assertNotNull($issue->archived_at);
+        $this->assertNull($issue->archived_reason);
+    }
+
+    public function test_archive_blocked_when_run_is_in_flight(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source, ['status' => IssueStatus::InProgress]);
+        Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Running,
+        ]);
+
+        Livewire::test('pages::intake')
+            ->call('archiveIssue', $issue->id);
+
+        // The issue must NOT be archived — in-flight run blocks the action.
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+    }
+
+    public function test_archive_allowed_when_run_is_completed(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source, ['status' => IssueStatus::Completed]);
+        Run::factory()->create([
+            'issue_id' => $issue->id,
+            'status' => RunStatus::Completed,
+        ]);
+
+        Livewire::test('pages::intake')
+            ->call('archiveIssue', $issue->id);
+
+        $issue->refresh();
+        $this->assertNotNull($issue->archived_at);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Unarchive action (Livewire)
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_unarchive_issue_via_livewire(): void
+    {
+        $source = $this->createSource();
+        $issue = $this->createIssue($source, ['title' => 'Unarchive me']);
+        $issue->archive('old reason');
+
+        Livewire::test('pages::intake')
+            ->call('unarchiveIssue', $issue->id);
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertNull($issue->archived_reason);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Auto-unarchive on sync: upsertIssue
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_upsert_issue_unarchives_existing_archived_row(): void
+    {
+        $source = $this->createSource();
+        $issue = Issue::factory()->archived('stale')->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#99',
+            'title' => 'Old title',
+        ]);
+
+        $service = app(IssueIntakeService::class);
+        $service->upsertIssue($source, [
+            'external_id' => 'owner/repo#99',
+            'title' => 'Updated title',
+            'body' => 'body',
+            'external_url' => 'https://example.com',
+            'assignee' => null,
+            'labels' => [],
+            'raw_status' => null,
+        ]);
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertNull($issue->archived_reason);
+        $this->assertEquals('Updated title', $issue->title);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Auto-unarchive on sync: markClosed
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_mark_closed_unarchives_existing_archived_row(): void
+    {
+        $source = $this->createSource();
+        $issue = Issue::factory()->archived()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#10',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $service = app(IssueIntakeService::class);
+        $service->markClosed($source, 'owner/repo#10', 'completed');
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertEquals('closed:completed', $issue->raw_status);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Auto-unarchive on sync: markReopened
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_mark_reopened_unarchives_existing_archived_row(): void
+    {
+        $source = $this->createSource();
+        $issue = Issue::factory()->archived()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#11',
+            'status' => IssueStatus::Rejected,
+            'raw_status' => 'closed:completed',
+        ]);
+
+        $service = app(IssueIntakeService::class);
+        $service->markReopened($source, 'owner/repo#11');
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertEquals(IssueStatus::Queued, $issue->status);
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Auto-unarchive on sync: markDeleted
+    // ──────────────────────────────────────────────────────────────
+
+    public function test_mark_deleted_unarchives_existing_archived_row(): void
+    {
+        $source = $this->createSource();
+        $issue = Issue::factory()->archived()->create([
+            'source_id' => $source->id,
+            'external_id' => 'owner/repo#12',
+            'status' => IssueStatus::Queued,
+        ]);
+
+        $service = app(IssueIntakeService::class);
+        $service->markDeleted($source, 'owner/repo#12');
+
+        $issue->refresh();
+        $this->assertNull($issue->archived_at);
+        $this->assertEquals(IssueStatus::Rejected, $issue->status);
+        $this->assertEquals('deleted', $issue->raw_status);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `archived_at` (nullable timestamp) and `archived_reason` (nullable string) columns to `issues` table with a composite index on `(source_id, archived_at)`
- Model gains `scopeActive`, `scopeArchived`, `archive(?string $reason)`, and `unarchive()` — status is left unchanged by archiving
- `IssueIntakeService` auto-unarchives issues matched in `upsertIssue`, `markClosed`, `markReopened`, and `markDeleted` so sync always wins over a local hide
- Intake queue defaults to active (non-archived) issues; "Show Archived" toggle reveals archived cards with an Unarchive button; Archive action uses Alpine.js `prompt()` for optional reason input
- Archiving is blocked when the issue has an in-flight Run (Pending / Running / Stuck)
- Issue detail page gains an Archive button that redirects back to `/intake` on success
- 18 PHPUnit feature tests cover all acceptance criteria; PHPStan baseline shrunk (net −90 lines) after adding `@extends Factory<Issue>` generic

## Test plan

- [ ] Run `php artisan test --compact tests/Feature/IssueArchiveTest.php` — all 18 tests pass
- [ ] Run `php artisan test --compact` — full suite passes (848 tests)
- [ ] Verify archive button appears on intake cards and prompts for a reason
- [ ] Verify "Show Archived" toggle reveals archived cards with reason and Unarchive button
- [ ] Verify in-flight issue cannot be archived
- [ ] Verify syncing a previously-archived issue auto-unarchives it

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)