### PR TITLE
feat: preflight clarification loop — round cap + abort (#21)

### DIFF
--- a/app/Enums/StuckState.php
+++ b/app/Enums/StuckState.php
@@ -9,4 +9,5 @@ enum StuckState: string
     case AgentUncertain = 'agent_uncertain';
     case ExternalBlocker = 'external_blocker';
     case JobFailed = 'job_failed';
+    case PreflightNoConsensus = 'preflight_no_consensus';
 }

--- a/app/Models/Run.php
+++ b/app/Models/Run.php
@@ -27,6 +27,8 @@ use Illuminate\Support\Carbon;
  * @property array<int, mixed>|null $known_facts
  * @property array<int, array<string, mixed>>|null $clarification_questions
  * @property array<string, mixed>|null $clarification_answers
+ * @property int $preflight_round
+ * @property array<int, array<string, mixed>>|null $clarification_history
  * @property int $iteration
  * @property bool $has_conflicts
  * @property Carbon|null $conflict_detected_at
@@ -55,6 +57,8 @@ class Run extends Model
         'known_facts',
         'clarification_questions',
         'clarification_answers',
+        'preflight_round',
+        'clarification_history',
         'iteration',
         'has_conflicts',
         'conflict_detected_at',
@@ -72,9 +76,11 @@ class Run extends Model
             'known_facts' => 'array',
             'clarification_questions' => 'array',
             'clarification_answers' => 'array',
+            'clarification_history' => 'array',
             'conflict_files' => 'array',
             'stuck_unread' => 'boolean',
             'has_conflicts' => 'boolean',
+            'preflight_round' => 'integer',
             'iteration' => 'integer',
             'started_at' => 'datetime',
             'completed_at' => 'datetime',

--- a/app/Services/PreflightAgent.php
+++ b/app/Services/PreflightAgent.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Enums\StageName;
+use App\Enums\StuckState;
+use App\Models\Run;
 use App\Models\Stage;
 use App\Models\StageEvent;
 use App\Services\AiProviders\AiProviderManager;
@@ -13,24 +15,28 @@ class PreflightAgent
     private const SYSTEM_PROMPT = <<<'PROMPT'
 You are the Preflight Agent for Relay, an agentic issue pipeline. Your job is to assess incoming issues and determine if they are clear enough to implement, or if they need clarification.
 
-## Confidence Rubric
+## Readiness Rubric
 
-An issue is **clear** when ALL of these are true:
+An issue is **ready** when ALL of these are true:
 - The desired behavior or change is explicitly stated
 - Acceptance criteria are present or can be directly inferred
 - The scope is bounded (you know what's in and out)
 - No ambiguous pronouns or references that could mean multiple things
 
-An issue is **ambiguous** when ANY of these are true:
+An issue is **not ready** when ANY of these are true:
 - The requirements are vague or open to multiple interpretations
 - Critical context is missing (which component, what data, what platform)
 - The scope is unbounded or unclear
 - There are implicit assumptions that need confirmation
 - Multiple valid approaches exist and the preferred one isn't specified
 
+## Clarification Loop
+
+The user may have already answered earlier questions — those answers appear in the user message under "## Clarification Answers". Use them to revise your assessment. If the answers resolve all ambiguity, mark the issue ready. If they raise new ambiguity or leave gaps, ask follow-up questions targeting the remaining gaps only — do NOT repeat resolved questions.
+
 ## Instructions
 
-Analyze the issue and call the `assess_issue` tool with your assessment. Always include known facts extracted from the issue. If ambiguous, generate clarifying questions — prefer radio-button choices when there are a small number of clear options, use free-text when the answer space is open-ended.
+Analyze the issue and call the `assess_issue` tool with your assessment. Always include known facts extracted from the issue. If not ready, generate clarifying questions — prefer radio-button choices when there are a small number of clear options, use free-text when the answer space is open-ended.
 PROMPT;
 
     private const DOC_SYSTEM_PROMPT = <<<'PROMPT'
@@ -52,10 +58,9 @@ PROMPT;
         'parameters' => [
             'type' => 'object',
             'properties' => [
-                'confidence' => [
-                    'type' => 'string',
-                    'enum' => ['clear', 'ambiguous'],
-                    'description' => 'Whether the issue is clear enough to implement or needs clarification.',
+                'ready' => [
+                    'type' => 'boolean',
+                    'description' => 'True when the issue is clear enough to implement, false when clarifying questions are needed.',
                 ],
                 'known_facts' => [
                     'type' => 'array',
@@ -78,10 +83,10 @@ PROMPT;
                         ],
                         'required' => ['id', 'text', 'type'],
                     ],
-                    'description' => 'Clarifying questions to ask the user (only when ambiguous).',
+                    'description' => 'Clarifying questions to ask the user (required when ready is false).',
                 ],
             ],
-            'required' => ['confidence', 'known_facts'],
+            'required' => ['ready', 'known_facts'],
         ],
     ];
 
@@ -153,18 +158,45 @@ PROMPT;
         PipelineLogger::event($run, 'preflight.execute_started', [
             'stage' => $stage->name->value,
             'iteration' => $stage->iteration,
+            'preflight_round' => $run->preflight_round,
             'has_clarification_answers' => $run->clarification_answers !== null,
         ]);
 
-        if ($run->clarification_answers !== null || ($context['skip_to_doc'] ?? false)) {
+        // Explicit skip-to-doc shortcut (user chose "Proceed without answers").
+        if ($context['skip_to_doc'] ?? false) {
             $this->generateAndStoreDoc($stage);
 
             return;
         }
 
+        // A resume with answers means we're entering a new clarification
+        // round. Enforce the round cap before invoking the model again.
+        if ($run->clarification_answers !== null) {
+            $maxRounds = (int) config('relay.preflight.max_clarification_rounds', 3);
+            $nextRound = $run->preflight_round + 1;
+
+            if ($nextRound > $maxRounds) {
+                $this->abortNoConsensus($stage, $nextRound, $maxRounds);
+
+                return;
+            }
+
+            $run->update(['preflight_round' => $nextRound]);
+
+            $this->recordEvent($stage, 'clarification_round_started', 'preflight_agent', [
+                'round' => $nextRound,
+                'max_rounds' => $maxRounds,
+            ]);
+            PipelineLogger::event($run, 'preflight.clarification_round_started', [
+                'stage' => $stage->name->value,
+                'round' => $nextRound,
+                'max_rounds' => $maxRounds,
+            ]);
+        }
+
         $provider = $this->providerManager->resolve(null, StageName::Preflight);
 
-        $messages = $this->buildMessages($issue, $run->worktree_path, $context);
+        $messages = $this->buildMessages($issue, $run, $context);
         $response = $provider->chat($messages, [self::ASSESS_TOOL], array_filter([
             'cwd' => $run->worktree_path,
             'log_context' => [
@@ -177,43 +209,103 @@ PROMPT;
 
         $assessment = $this->parseAssessment($response);
 
-        $run->update([
-            'known_facts' => $assessment['known_facts'],
-        ]);
+        // Only overwrite known_facts when the model actually returned an
+        // assessment. Falling back to the default `ready: true` should not
+        // wipe facts accumulated in earlier rounds.
+        if ($assessment['parsed']) {
+            $run->update([
+                'known_facts' => $assessment['known_facts'],
+            ]);
+        }
 
         $this->recordEvent($stage, 'assessment_complete', 'preflight_agent', [
-            'confidence' => $assessment['confidence'],
+            'ready' => $assessment['ready'],
+            'round' => $run->fresh()->preflight_round,
             'known_facts_count' => count($assessment['known_facts']),
-            'questions_count' => count($assessment['questions'] ?? []),
+            'questions_count' => count($assessment['questions']),
         ]);
 
         PipelineLogger::event($run, 'preflight.assessment_complete', [
             'stage' => $stage->name->value,
-            'confidence' => $assessment['confidence'],
+            'ready' => $assessment['ready'],
+            'round' => $run->fresh()->preflight_round,
             'known_facts_count' => count($assessment['known_facts']),
-            'questions_count' => count($assessment['questions'] ?? []),
+            'questions_count' => count($assessment['questions']),
         ]);
 
-        if ($assessment['confidence'] === 'clear') {
+        if ($assessment['ready']) {
             $this->generateAndStoreDoc($stage);
 
             return;
         }
 
+        // Still ambiguous. Archive current Q&A into history, store the new
+        // questions, clear answers so the resume path fires a fresh round.
+        $this->archiveClarificationRound($run);
+
         $run->update([
-            'clarification_questions' => $assessment['questions'] ?? [],
+            'clarification_questions' => $assessment['questions'],
+            'clarification_answers' => null,
         ]);
 
         $this->recordEvent($stage, 'clarification_needed', 'preflight_agent', [
-            'questions' => $assessment['questions'] ?? [],
+            'round' => $run->fresh()->preflight_round,
+            'questions' => $assessment['questions'],
         ]);
 
         PipelineLogger::event($run, 'preflight.clarification_needed', [
             'stage' => $stage->name->value,
-            'questions_count' => count($assessment['questions'] ?? []),
+            'round' => $run->fresh()->preflight_round,
+            'questions_count' => count($assessment['questions']),
         ]);
 
         $this->orchestrator->pause($stage);
+    }
+
+    /**
+     * Push the current Q&A pair into clarification_history (kept in known_facts
+     * adjacent storage via a session-scoped round marker) before overwriting
+     * with the next round's questions.
+     */
+    private function archiveClarificationRound(Run $run): void
+    {
+        if (empty($run->clarification_questions) && empty($run->clarification_answers)) {
+            return;
+        }
+
+        $history = $run->clarification_history ?? [];
+        $history[] = [
+            'round' => $run->preflight_round,
+            'questions' => $run->clarification_questions ?? [],
+            'answers' => $run->clarification_answers ?? [],
+            'recorded_at' => now()->toIso8601String(),
+        ];
+
+        $run->update(['clarification_history' => $history]);
+    }
+
+    private function abortNoConsensus(Stage $stage, int $attemptedRound, int $maxRounds): void
+    {
+        $run = $stage->run;
+
+        $this->archiveClarificationRound($run);
+
+        $this->recordEvent($stage, 'preflight_no_consensus', 'preflight_agent', [
+            'attempted_round' => $attemptedRound,
+            'max_rounds' => $maxRounds,
+        ]);
+
+        PipelineLogger::event($run, 'preflight.no_consensus', [
+            'stage' => $stage->name->value,
+            'attempted_round' => $attemptedRound,
+            'max_rounds' => $maxRounds,
+        ]);
+
+        $this->orchestrator->markStuck($stage, StuckState::PreflightNoConsensus, [
+            'attempted_round' => $attemptedRound,
+            'max_rounds' => $maxRounds,
+            'raw_status' => 'preflight_no_consensus',
+        ]);
     }
 
     private function generateAndStoreDoc(Stage $stage): void
@@ -288,6 +380,8 @@ PROMPT;
             $content .= "- {$fact}\n";
         }
 
+        $content .= $this->formatClarificationHistory($run);
+
         if ($run->clarification_answers) {
             $content .= "\n## Clarification Answers\n";
             $questions = $run->clarification_questions ?? [];
@@ -301,6 +395,28 @@ PROMPT;
         $messages[] = ['role' => 'user', 'content' => $content];
 
         return $messages;
+    }
+
+    private function formatClarificationHistory($run): string
+    {
+        $history = $run->clarification_history ?? [];
+        if (empty($history)) {
+            return '';
+        }
+
+        $content = "\n## Previous Clarification Rounds\n";
+        foreach ($history as $round) {
+            $questions = collect($round['questions'] ?? [])->keyBy('id');
+            $answers = $round['answers'] ?? [];
+            $roundNumber = $round['round'] ?? '?';
+            $content .= "\n### Round {$roundNumber}\n";
+            foreach ($answers as $questionId => $answer) {
+                $questionText = $questions[$questionId]['text'] ?? $questionId;
+                $content .= "- **{$questionText}**: {$answer}\n";
+            }
+        }
+
+        return $content;
     }
 
     private function parseDocResponse(array $response): array
@@ -360,7 +476,7 @@ PROMPT;
         return $doc;
     }
 
-    private function buildMessages($issue, ?string $worktreePath, array $context): array
+    private function buildMessages($issue, $run, array $context): array
     {
         $messages = [
             ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
@@ -377,9 +493,23 @@ PROMPT;
             $issueContent .= "Assignee: {$issue->assignee}\n";
         }
 
-        $repoListing = $this->buildRepoListing($worktreePath);
+        $repoListing = $this->buildRepoListing($run->worktree_path ?? null);
         if ($repoListing !== '') {
             $issueContent .= "\n## Repository file listing\n\n{$repoListing}";
+        }
+
+        // Append previous-round history and the most recent answers so the
+        // model can refine its assessment during a clarification loop.
+        $issueContent .= $this->formatClarificationHistory($run);
+
+        if (! empty($run->clarification_answers)) {
+            $issueContent .= "\n## Clarification Answers (current round)\n";
+            $questions = $run->clarification_questions ?? [];
+            foreach ($run->clarification_answers as $questionId => $answer) {
+                $question = collect($questions)->firstWhere('id', $questionId);
+                $questionText = $question['text'] ?? $questionId;
+                $issueContent .= "- **{$questionText}**: {$answer}\n";
+            }
         }
 
         $messages[] = ['role' => 'user', 'content' => $issueContent];
@@ -467,18 +597,39 @@ PROMPT;
         return $output;
     }
 
+    /**
+     * Parse the assess_issue tool call. Returns a normalised assessment plus
+     * a `parsed` flag so callers can distinguish a real response from the
+     * fallback default (used when the model didn't call the tool).
+     *
+     * @return array{ready: bool, known_facts: array<int, string>, questions: array<int, array<string, mixed>>, parsed: bool}
+     */
     private function parseAssessment(array $response): array
     {
         foreach ($response['tool_calls'] ?? [] as $toolCall) {
             if ($toolCall['name'] === 'assess_issue') {
-                return $toolCall['arguments'];
+                $args = $toolCall['arguments'];
+
+                // Backward-compat: older prompt variants returned `confidence`
+                // instead of `ready`. Normalise so downstream logic is simple.
+                if (! array_key_exists('ready', $args) && array_key_exists('confidence', $args)) {
+                    $args['ready'] = $args['confidence'] === 'clear';
+                }
+
+                return [
+                    'ready' => (bool) ($args['ready'] ?? true),
+                    'known_facts' => $args['known_facts'] ?? [],
+                    'questions' => $args['questions'] ?? [],
+                    'parsed' => true,
+                ];
             }
         }
 
         return [
-            'confidence' => 'clear',
+            'ready' => true,
             'known_facts' => [],
             'questions' => [],
+            'parsed' => false,
         ];
     }
 

--- a/app/Services/PreflightAgent.php
+++ b/app/Services/PreflightAgent.php
@@ -159,7 +159,7 @@ PROMPT;
             'stage' => $stage->name->value,
             'iteration' => $stage->iteration,
             'preflight_round' => $run->preflight_round,
-            'has_clarification_answers' => $run->clarification_answers !== null,
+            'has_clarification_answers' => ! empty($run->clarification_answers),
         ]);
 
         // Explicit skip-to-doc shortcut (user chose "Proceed without answers").
@@ -169,9 +169,11 @@ PROMPT;
             return;
         }
 
-        // A resume with answers means we're entering a new clarification
-        // round. Enforce the round cap before invoking the model again.
-        if ($run->clarification_answers !== null) {
+        // A resume with at least one answer means we're entering a new
+        // clarification round. Enforce the round cap before invoking the
+        // model again. An empty array (form submitted with no answers)
+        // does not consume a round.
+        if (! empty($run->clarification_answers)) {
             $maxRounds = (int) config('relay.preflight.max_clarification_rounds', 3);
             $nextRound = $run->preflight_round + 1;
 
@@ -220,7 +222,7 @@ PROMPT;
 
         $this->recordEvent($stage, 'assessment_complete', 'preflight_agent', [
             'ready' => $assessment['ready'],
-            'round' => $run->fresh()->preflight_round,
+            'round' => $run->preflight_round,
             'known_facts_count' => count($assessment['known_facts']),
             'questions_count' => count($assessment['questions']),
         ]);
@@ -228,7 +230,7 @@ PROMPT;
         PipelineLogger::event($run, 'preflight.assessment_complete', [
             'stage' => $stage->name->value,
             'ready' => $assessment['ready'],
-            'round' => $run->fresh()->preflight_round,
+            'round' => $run->preflight_round,
             'known_facts_count' => count($assessment['known_facts']),
             'questions_count' => count($assessment['questions']),
         ]);
@@ -249,13 +251,13 @@ PROMPT;
         ]);
 
         $this->recordEvent($stage, 'clarification_needed', 'preflight_agent', [
-            'round' => $run->fresh()->preflight_round,
+            'round' => $run->preflight_round,
             'questions' => $assessment['questions'],
         ]);
 
         PipelineLogger::event($run, 'preflight.clarification_needed', [
             'stage' => $stage->name->value,
-            'round' => $run->fresh()->preflight_round,
+            'round' => $run->preflight_round,
             'questions_count' => count($assessment['questions']),
         ]);
 
@@ -411,7 +413,8 @@ PROMPT;
             $roundNumber = $round['round'] ?? '?';
             $content .= "\n### Round {$roundNumber}\n";
             foreach ($answers as $questionId => $answer) {
-                $questionText = $questions[$questionId]['text'] ?? $questionId;
+                $question = $questions->get($questionId);
+                $questionText = is_array($question) ? ($question['text'] ?? $questionId) : $questionId;
                 $content .= "- **{$questionText}**: {$answer}\n";
             }
         }
@@ -503,7 +506,7 @@ PROMPT;
         $issueContent .= $this->formatClarificationHistory($run);
 
         if (! empty($run->clarification_answers)) {
-            $issueContent .= "\n## Clarification Answers (current round)\n";
+            $issueContent .= "\n## Clarification Answers\n";
             $questions = $run->clarification_questions ?? [];
             foreach ($run->clarification_answers as $questionId => $answer) {
                 $question = collect($questions)->firstWhere('id', $questionId);

--- a/config/relay.php
+++ b/config/relay.php
@@ -10,6 +10,10 @@ return [
         'stage_job_timeout' => (int) env('RELAY_STAGE_JOB_TIMEOUT', 600),
     ],
 
+    'preflight' => [
+        'max_clarification_rounds' => (int) env('RELAY_PREFLIGHT_MAX_CLARIFICATION_ROUNDS', 3),
+    ],
+
     'worktree' => [
         'git_timeout' => (int) env('RELAY_WORKTREE_GIT_TIMEOUT', 60),
         'stale_lock_seconds' => (int) env('RELAY_WORKTREE_STALE_LOCK_SECONDS', 300),

--- a/database/migrations/2026_04_18_172549_add_preflight_round_to_runs_table.php
+++ b/database/migrations/2026_04_18_172549_add_preflight_round_to_runs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->unsignedInteger('preflight_round')->default(0)->after('clarification_answers');
+            $table->json('clarification_history')->nullable()->after('preflight_round');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->dropColumn(['preflight_round', 'clarification_history']);
+        });
+    }
+};

--- a/resources/views/pages/⚡preflight-clarification.blade.php
+++ b/resources/views/pages/⚡preflight-clarification.blade.php
@@ -97,6 +97,8 @@ class extends Component
         return [
             'knownFacts' => $this->run->known_facts ?? [],
             'questions' => $this->run->clarification_questions ?? [],
+            'currentRound' => $this->run->preflight_round + 1,
+            'maxRounds' => (int) config('relay.preflight.max_clarification_rounds', 3),
         ];
     }
 };
@@ -114,6 +116,9 @@ class extends Component
         @if ($run->issue->external_id)
             <span class="text-outline">({{ $run->issue->external_id }})</span>
         @endif
+    </p>
+    <p class="mt-2 inline-flex items-center gap-2 rounded-full bg-surface-container-high px-3 py-1 text-xs font-medium text-on-surface-variant">
+        Round {{ $currentRound }} of {{ $maxRounds }}
     </p>
 </div>
 

--- a/tests/Feature/PreflightAgentTest.php
+++ b/tests/Feature/PreflightAgentTest.php
@@ -7,6 +7,7 @@ use App\Enums\IssueStatus;
 use App\Enums\RunStatus;
 use App\Enums\StageName;
 use App\Enums\StageStatus;
+use App\Enums\StuckState;
 use App\Jobs\ExecuteStageJob;
 use App\Models\Issue;
 use App\Models\Run;
@@ -317,7 +318,7 @@ class PreflightAgentTest extends TestCase
         $event = $stage->events()->where('type', 'assessment_complete')->first();
         $this->assertNotNull($event);
         $this->assertEquals('preflight_agent', $event->actor);
-        $this->assertEquals('clear', $event->payload['confidence']);
+        $this->assertTrue($event->payload['ready']);
         $this->assertEquals(2, $event->payload['known_facts_count']);
     }
 
@@ -853,6 +854,230 @@ class PreflightAgentTest extends TestCase
         $this->assertNotNull($run->preflight_doc);
         $this->assertStringContainsString('## Summary', $run->preflight_doc);
         $this->assertEquals(['q1' => 'Bar'], $run->clarification_answers);
+    }
+
+    // === Clarification Loop Tests ===
+
+    public function test_resume_with_answers_reruns_assess_when_still_ambiguous(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        $run->update([
+            'known_facts' => ['Some fact'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which?', 'type' => 'text'],
+            ],
+            'clarification_answers' => ['q1' => 'Dashboard'],
+        ]);
+
+        // Only one assess response returned — still ambiguous after answers.
+        $newQuestions = [
+            ['id' => 'q2', 'text' => 'Which dashboard type?', 'type' => 'text'],
+        ];
+        $this->bindMockProvider($this->mockAmbiguousResponse(['Refined fact'], $newQuestions));
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $stage->refresh();
+
+        $this->assertEquals(1, $run->preflight_round);
+        // New questions replace prior ones.
+        $this->assertCount(1, $run->clarification_questions);
+        $this->assertEquals('q2', $run->clarification_questions[0]['id']);
+        // Answers are cleared so the next resume fires a fresh round.
+        $this->assertNull($run->clarification_answers);
+        // History holds the prior round.
+        $this->assertNotNull($run->clarification_history);
+        $this->assertCount(1, $run->clarification_history);
+        $this->assertEquals(['q1' => 'Dashboard'], $run->clarification_history[0]['answers']);
+        // Stage paused again, not completed.
+        $this->assertEquals(StageStatus::AwaitingApproval, $stage->status);
+        $this->assertNull($run->preflight_doc);
+    }
+
+    public function test_resume_with_answers_proceeds_to_doc_when_ready(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        $run->update([
+            'known_facts' => ['Some fact'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which?', 'type' => 'text'],
+            ],
+            'clarification_answers' => ['q1' => 'Admin'],
+        ]);
+
+        $this->bindMultiCallProvider([
+            $this->mockClearResponse(['Refined fact']),
+            $this->mockDocResponse(),
+        ]);
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $stage->refresh();
+
+        $this->assertEquals(1, $run->preflight_round);
+        $this->assertEquals(StageStatus::Completed, $stage->status);
+        $this->assertNotNull($run->preflight_doc);
+    }
+
+    public function test_round_cap_aborts_with_preflight_no_consensus(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        // Configure a tight cap for the test.
+        config()->set('relay.preflight.max_clarification_rounds', 2);
+
+        $run->update([
+            'preflight_round' => 2,
+            'known_facts' => ['Something'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which?', 'type' => 'text'],
+            ],
+            'clarification_answers' => ['q1' => 'Dashboard'],
+        ]);
+
+        // No provider response should be consumed — aborting early.
+        $this->bindMockProvider($this->mockAmbiguousResponse());
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $stage->refresh();
+
+        $this->assertEquals(RunStatus::Stuck, $run->status);
+        $this->assertEquals(StuckState::PreflightNoConsensus, $run->stuck_state);
+        $this->assertEquals(StageStatus::Stuck, $stage->status);
+
+        $event = $stage->events()->where('type', 'preflight_no_consensus')->first();
+        $this->assertNotNull($event);
+        $this->assertEquals(3, $event->payload['attempted_round']);
+        $this->assertEquals(2, $event->payload['max_rounds']);
+    }
+
+    public function test_preflight_round_increments_across_resumes(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        $run->update([
+            'known_facts' => ['Fact'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which?', 'type' => 'text'],
+            ],
+            'clarification_answers' => ['q1' => 'Admin'],
+        ]);
+
+        $this->bindMockProvider($this->mockAmbiguousResponse(['Fact'], [
+            ['id' => 'q2', 'text' => 'More detail?', 'type' => 'text'],
+        ]));
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $this->assertEquals(1, $run->preflight_round);
+
+        // Simulate a second resume.
+        $run->update(['clarification_answers' => ['q2' => 'whatever']]);
+        $stage->refresh();
+        $stage->update(['status' => StageStatus::Running]);
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $this->assertEquals(2, $run->preflight_round);
+    }
+
+    public function test_skip_to_doc_does_not_increment_round(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        $run->update([
+            'known_facts' => ['Some facts here'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Question?', 'type' => 'text'],
+            ],
+            'preflight_round' => 1,
+        ]);
+
+        $this->bindMultiCallProvider([
+            $this->mockDocResponse(),
+        ]);
+
+        app(PreflightAgent::class)->execute($stage, ['skip_to_doc' => true]);
+
+        $run->refresh();
+        // Round is unchanged when skipping.
+        $this->assertEquals(1, $run->preflight_round);
+    }
+
+    public function test_initial_execute_does_not_consume_a_round(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+
+        // First execute: no answers set yet. Ambiguous response → pauses.
+        $this->bindMockProvider($this->mockAmbiguousResponse());
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $run->refresh();
+        $this->assertEquals(0, $run->preflight_round);
+    }
+
+    public function test_preflight_clarification_page_shows_round_counter(): void
+    {
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+        $run->update([
+            'preflight_round' => 1,
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Follow-up?', 'type' => 'text'],
+            ],
+        ]);
+
+        config()->set('relay.preflight.max_clarification_rounds', 3);
+
+        $response = $this->get(route('preflight.show', $run));
+
+        $response->assertOk();
+        // Round counter surfaces the upcoming round (preflight_round + 1) out of max.
+        $response->assertSee('Round 2 of 3');
+    }
+
+    public function test_clarification_history_feeds_next_round_prompt(): void
+    {
+        Queue::fake();
+        [$issue, $run, $stage] = $this->setupRunWithStage();
+        $stage->update(['status' => StageStatus::AwaitingApproval]);
+
+        $run->update([
+            'known_facts' => ['Fact'],
+            'clarification_questions' => [
+                ['id' => 'q1', 'text' => 'Which dashboard?', 'type' => 'text'],
+            ],
+            'clarification_answers' => ['q1' => 'Admin'],
+        ]);
+
+        $mock = $this->bindCapturingProvider();
+
+        app(PreflightAgent::class)->execute($stage, []);
+
+        $userMessage = collect($mock->capturedMessages)->firstWhere('role', 'user')['content'];
+        $this->assertStringContainsString('Clarification Answers', $userMessage);
+        $this->assertStringContainsString('Which dashboard?', $userMessage);
+        $this->assertStringContainsString('Admin', $userMessage);
     }
 
     // === Migration Tests ===


### PR DESCRIPTION
Closes #21.

## What shipped (priority 1+2)

- **Bounded clarification loop.** Resume-with-answers now re-runs the preflight assessment instead of skipping straight to doc generation. If the model still marks the issue ambiguous the stage is re-paused with a fresh set of questions targeted at the remaining gaps; if ready it proceeds to doc.
- **Round cap + abort path.** New `relay.preflight.max_clarification_rounds` config (default 3). On the (N+1)-th resume the run transitions to Stuck with the new `StuckState::PreflightNoConsensus` state. `raw_status = 'preflight_no_consensus'` is recorded in the stage event payload. The existing intake/overview/activity pages already render `stuck_state->value` so this surfaces without UI plumbing.
- **In-app channel (priority 2).** The existing `/runs/{run}/preflight` page keeps working; no route or stage-lookup changes needed. Added a "Round N of M" chip on the page header.
- **Structured decision.** The `assess_issue` tool now returns `{ ready: bool, known_facts: [], questions?: [] }`. Parser keeps a backward-compat branch for the old `confidence: 'clear'|'ambiguous'` shape so in-flight prompts don't regress.
- **Clarification history.** Each round's Q&A is archived to a new `runs.clarification_history` JSON column and folded back into the next assess prompt so the model refines rather than repeats questions.
- **Schema.** Adds `preflight_round` (uint, default 0) and `clarification_history` (json, nullable) to `runs`.
- **Tests.** New feature tests cover: resume with answers re-runs assess when still ambiguous; resume with answers goes to doc when ready; round cap triggers `PreflightNoConsensus`; round increments across resumes; skip-to-doc does not consume a round; initial execute does not consume a round; clarification history feeds the next round prompt; blade shows round counter.

## Explicitly deferred (priorities 3+4)

Per the "don't ship half-wired features" rule, the `on_issue` channel is entirely deferred — posting would land without ingest or vice versa. Shipping neither keeps the in-app path the single source of truth.

- `on_issue` channel: posting clarifying questions as GitHub/Jira issue comments and ingesting replies via webhook
- Bot-identity capture at OAuth exchange (`bot_login`, `bot_account_id`)
- `GitHubWebhookManager::EVENTS` / `JiraWebhookManager::EVENTS` extension for `issue_comment`
- `ProcessGitHubIssueCommentJob` / `ProcessJiraIssueCommentJob` + `ResumePreflightFromCommentJob`
- Self-authored comment filter (stored bot identity vs comment author)
- `sources.config.preflight.clarification_channel` enum + UI toggle
- Mode switch mid-flight semantics

## Design notes / trade-offs

- **Reused `StageStatus::AwaitingApproval`** instead of adding a new `PreflightClarifying` case. The task flagged this as an acceptable reduction; the existing preflight page keys off `AwaitingApproval` and works unmodified across rounds.
- **Renamed `confidence` to `ready`** in the assess tool schema per the spec. Kept a compat branch in `parseAssessment` so older cached prompt variants still parse.
- **`known_facts` is only overwritten when the model actually returns an assess tool call.** Fallback default no longer wipes facts accumulated in earlier rounds — caught this when a regression appeared in `PreflightDocTest`.

## Test plan

- [x] `php artisan test --compact` — 887 passing, 0 failing
- [x] `vendor/bin/pint --dirty --format agent` — clean
- [x] `vendor/bin/phpstan analyse --no-progress --memory-limit=1G` — no errors, no new baseline entries
- [ ] Manual QA: verify a real ambiguous issue loops through 2 rounds then proceeds to doc, and a 4-round ambiguous issue transitions to Stuck with `preflight_no_consensus` visible on the intake page

🤖 Generated with [Claude Code](https://claude.com/claude-code)